### PR TITLE
Add workflow to publish monthly benchmark results

### DIFF
--- a/.github/workflows/update-test-results.yml
+++ b/.github/workflows/update-test-results.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: '0 0 1 * *'
 
+permissions:
+  contents: write
+
 jobs:
   tests:
     runs-on: ubuntu-latest
@@ -12,10 +15,11 @@ jobs:
       - uses: actions/checkout@v4
       - name: Build and run benchmarks in Docker
         run: |
+          set -euo pipefail
           dirs=(php-di pimple quickly-configured quickly-reflection)
           for dir in "${dirs[@]}"; do
             docker build -t di-benchmark-"$dir" "$dir"
-            docker run --rm di-benchmark-"$dir" > "$dir".txt
+            docker run --rm di-benchmark-"$dir" 2>&1 | tee "$dir".txt
           done
           {
             echo '# PHP Dependency Injection Benchmark'

--- a/.github/workflows/update-test-results.yml
+++ b/.github/workflows/update-test-results.yml
@@ -1,0 +1,45 @@
+name: Update test results
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 1 * *'
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build and run benchmarks in Docker
+        run: |
+          dirs=(php-di pimple quickly-configured quickly-reflection)
+          for dir in "${dirs[@]}"; do
+            docker build -t di-benchmark-"$dir" "$dir"
+            docker run --rm di-benchmark-"$dir" > "$dir".txt
+          done
+          {
+            echo '# PHP Dependency Injection Benchmark'
+            echo
+            echo 'This repository benchmarks different dependency injection containers.'
+            echo
+            echo '## Test Results'
+            echo
+            echo 'Results from the latest automated run of the Dockerized benchmarks:'
+            echo
+            echo '```'
+            for dir in "${dirs[@]}"; do
+              echo "### $dir"
+              cat "$dir".txt
+              echo
+            done
+            echo '```'
+          } > README.md
+      - name: Commit results
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git add README.md
+          git commit -m "Update test results" || echo "No changes to commit"
+          git push
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# PHP Dependency Injection Benchmark
+
+This repository benchmarks different dependency injection containers.
+
+## Test Results
+
+Results from the latest automated run of the Dockerized benchmarks are written below.
+
+```
+No test results available yet.
+```


### PR DESCRIPTION
## Summary
- run benchmarks in docker containers within GitHub Actions and publish results to README
- clarify README test result section

## Testing
- `php -l benchmark.php`
- `php benchmark.php` *(fails: Failed to open stream: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b871c66368832fafa6eb604d704366

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced an automated workflow to run dependency injection benchmarks and update the public results monthly, with an option to trigger it manually.
* **Documentation**
  * Added a README describing the benchmark project and a Test Results section that will display the latest benchmark outputs.
* **Chores**
  * Set up continuous integration to build, run, and publish benchmark results, committing changes automatically when new data is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->