### PR TITLE
Add Laravel dependency injection container benchmark

### DIFF
--- a/laravel/Dockerfile
+++ b/laravel/Dockerfile
@@ -1,0 +1,8 @@
+FROM php:8.4-cli
+
+WORKDIR /app
+COPY composer.json ./
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
+    && composer install --no-interaction --no-progress
+COPY benchmark.php ./
+CMD ["php", "benchmark.php"]

--- a/laravel/benchmark.php
+++ b/laravel/benchmark.php
@@ -1,0 +1,39 @@
+<?php
+require_once 'vendor/autoload.php';
+
+use Illuminate\Container\Container;
+
+class A {}
+class B { public function __construct(A $a) {} }
+class C { public function __construct(B $b) {} }
+class D { public function __construct(C $c, B $b, A $a) {} }
+class E { public function __construct(D $d, C $c, B $b) {} }
+class F { public function __construct(E $e, D $d, B $b) {} }
+
+class LaravelAdapter {
+    private Container $container;
+    public function __construct() {
+        $this->container = new Container();
+    }
+    public function get(string $class): object {
+        return $this->container->make($class);
+    }
+}
+
+$adapter = new LaravelAdapter();
+$iterations = 10000;
+$runs = 5;
+$times = [];
+for ($j = 0; $j < $runs; $j++) {
+    $start = microtime(true);
+    for ($i = 0; $i < $iterations; $i++) {
+        $object = $adapter->get(F::class);
+        unset($object);
+    }
+    $time = microtime(true) - $start;
+    $times[] = $time;
+    echo "run $j: $time seconds per $iterations\n";
+}
+
+echo "\nAVERAGE | MINIMUM | MAXIMUM\n";
+echo (array_sum($times)/count($times)) . " | " . min($times) . " | " . max($times) . "\n";

--- a/laravel/composer.json
+++ b/laravel/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "illuminate/container": "^11.0"
+    }
+}


### PR DESCRIPTION
## Summary
- add Laravel container benchmark with PHP script, Dockerfile, and composer setup

## Testing
- `php -l laravel/benchmark.php`
- `composer validate laravel/composer.json`
- `composer install --working-dir=laravel --no-interaction --no-progress`


------
https://chatgpt.com/codex/tasks/task_e_68b87b39d1dc832fbf226800de851fed