### PR TITLE
Run benchmark workflow on pushes to main

### DIFF
--- a/.github/workflows/update-test-results.yml
+++ b/.github/workflows/update-test-results.yml
@@ -5,7 +5,8 @@ on:
   schedule:
     - cron: '0 0 1 * *'
   push:
-    branches: [main]
+    branches:
+      - the-one
 
 permissions:
   contents: write

--- a/.github/workflows/update-test-results.yml
+++ b/.github/workflows/update-test-results.yml
@@ -4,12 +4,15 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 0 1 * *'
+  push:
+    branches: [main]
 
 permissions:
   contents: write
 
 jobs:
   tests:
+    if: github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -24,11 +27,14 @@ jobs:
           {
             echo '# PHP Dependency Injection Benchmark'
             echo
-            echo 'This repository benchmarks different dependency injection containers.'
+              echo 'This repository benchmarks different dependency' \
+                   'injection containers.'
             echo
             echo '## Test Results'
             echo
-            echo 'Results from the latest automated run of the Dockerized benchmarks:'
+              echo 'Results from the latest automated run of the Dockerized' \
+                   'benchmarks' \
+                   '(triggered on pushes to main and a monthly schedule):'
             echo
             echo '```'
             for dir in "${dirs[@]}"; do
@@ -41,7 +47,8 @@ jobs:
       - name: Commit results
         run: |
           git config --global user.name 'github-actions[bot]'
-          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git config --global user.email \
+            'github-actions[bot]@users.noreply.github.com'
           git add README.md
           git commit -m "Update test results" || echo "No changes to commit"
           git push

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository benchmarks different dependency injection containers.
 
 ## Test Results
 
-Results from the latest automated run of the Dockerized benchmarks:
+Results from the latest automated run of the Dockerized benchmarks (triggered on pushes to main and a monthly schedule):
 
 ```
 ### php-di


### PR DESCRIPTION
## Summary
- run benchmark workflow on pushes to main
- document automatic runs on push in README

## Testing
- `yamllint .github/workflows/update-test-results.yml`
- `composer validate php-di/composer.json`


------
https://chatgpt.com/codex/tasks/task_e_68b881198884832f97bc0faee9875d68