### PR TITLE
Generate summary table in benchmark workflow

### DIFF
--- a/.github/workflows/update-test-results.yml
+++ b/.github/workflows/update-test-results.yml
@@ -21,9 +21,15 @@ jobs:
         run: |
           set -euo pipefail
           dirs=(php-di pimple quickly-configured quickly-reflection)
+          summary=""
           for dir in "${dirs[@]}"; do
             docker build -t di-benchmark-"$dir" "$dir"
             docker run --rm di-benchmark-"$dir" 2>&1 | tee "$dir".txt
+            line=$(tail -n 1 "$dir".txt)
+            avg=$(echo "$line" | awk -F'\|' '{print $1}' | tr -d ' ')
+            min=$(echo "$line" | awk -F'\|' '{print $2}' | tr -d ' ')
+            max=$(echo "$line" | awk -F'\|' '{print $3}' | tr -d ' ')
+            summary+="| $dir | $avg | $min | $max |\n"
           done
           {
             echo '# PHP Dependency Injection Benchmark'
@@ -44,6 +50,12 @@ jobs:
               echo
             done
             echo '```'
+            echo
+            echo '## Summary'
+            echo
+            echo '| Container | Average | Minimum | Maximum |'
+            echo '| --- | --- | --- | --- |'
+            printf "%b" "$summary"
           } > README.md
       - name: Commit results
         run: |


### PR DESCRIPTION
## Summary
- remove manual README edits and compute benchmark summary table in workflow

## Testing
- `composer test` *(fails: Command "test" is not defined.)*


------
https://chatgpt.com/codex/tasks/task_e_68b883d85060832fb9d59153941dad82