### PR TITLE
Add benchmark including container start-up time

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # PHP Dependency Injection Benchmark
 
 This repository benchmarks different dependency injection containers.
+Each benchmark now runs two test cases:
+one excluding the container start-up time and another including it.
 
 ## Test Results
 

--- a/laravel/benchmark.php
+++ b/laravel/benchmark.php
@@ -37,3 +37,20 @@ for ($j = 0; $j < $runs; $j++) {
 
 echo "\nAVERAGE | MINIMUM | MAXIMUM\n";
 echo (array_sum($times)/count($times)) . " | " . min($times) . " | " . max($times) . "\n";
+
+echo "\nINCLUDING STARTUP TIME\n";
+$times = [];
+for ($j = 0; $j < $runs; $j++) {
+    $start = microtime(true);
+    $adapter = new LaravelAdapter();
+    for ($i = 0; $i < $iterations; $i++) {
+        $object = $adapter->get(F::class);
+        unset($object);
+    }
+    $time = microtime(true) - $start;
+    $times[] = $time;
+    echo "run $j: $time seconds per $iterations\n";
+}
+
+echo "\nAVERAGE | MINIMUM | MAXIMUM\n";
+echo (array_sum($times)/count($times)) . " | " . min($times) . " | " . max($times) . "\n";

--- a/nette-di/benchmark.php
+++ b/nette-di/benchmark.php
@@ -51,3 +51,20 @@ for ($j = 0; $j < $runs; $j++) {
 
 echo "\nAVERAGE | MINIMUM | MAXIMUM\n";
 echo (array_sum($times)/count($times)) . " | " . min($times) . " | " . max($times) . "\n";
+
+echo "\nINCLUDING STARTUP TIME\n";
+$times = [];
+for ($j = 0; $j < $runs; $j++) {
+    $start = microtime(true);
+    $adapter = new NetteDiAdapter();
+    for ($i = 0; $i < $iterations; $i++) {
+        $object = $adapter->get(F::class);
+        unset($object);
+    }
+    $time = microtime(true) - $start;
+    $times[] = $time;
+    echo "run $j: $time seconds per $iterations\n";
+}
+
+echo "\nAVERAGE | MINIMUM | MAXIMUM\n";
+echo (array_sum($times)/count($times)) . " | " . min($times) . " | " . max($times) . "\n";

--- a/php-di/benchmark.php
+++ b/php-di/benchmark.php
@@ -48,3 +48,20 @@ for ($j = 0; $j < $runs; $j++) {
 
 echo "\nAVERAGE | MINIMUM | MAXIMUM\n";
 echo (array_sum($times)/count($times)) . " | " . min($times) . " | " . max($times) . "\n";
+
+echo "\nINCLUDING STARTUP TIME\n";
+$times = [];
+for ($j = 0; $j < $runs; $j++) {
+    $start = microtime(true);
+    $adapter = new PhpDiAdapter();
+    for ($i = 0; $i < $iterations; $i++) {
+        $object = $adapter->get(F::class);
+        unset($object);
+    }
+    $time = microtime(true) - $start;
+    $times[] = $time;
+    echo "run $j: $time seconds per $iterations\n";
+}
+
+echo "\nAVERAGE | MINIMUM | MAXIMUM\n";
+echo (array_sum($times)/count($times)) . " | " . min($times) . " | " . max($times) . "\n";

--- a/pimple/benchmark.php
+++ b/pimple/benchmark.php
@@ -44,3 +44,20 @@ for ($j = 0; $j < $runs; $j++) {
 
 echo "\nAVERAGE | MINIMUM | MAXIMUM\n";
 echo (array_sum($times)/count($times)) . " | " . min($times) . " | " . max($times) . "\n";
+
+echo "\nINCLUDING STARTUP TIME\n";
+$times = [];
+for ($j = 0; $j < $runs; $j++) {
+    $start = microtime(true);
+    $adapter = new PimpleAdapter();
+    for ($i = 0; $i < $iterations; $i++) {
+        $object = $adapter->get(F::class);
+        unset($object);
+    }
+    $time = microtime(true) - $start;
+    $times[] = $time;
+    echo "run $j: $time seconds per $iterations\n";
+}
+
+echo "\nAVERAGE | MINIMUM | MAXIMUM\n";
+echo (array_sum($times)/count($times)) . " | " . min($times) . " | " . max($times) . "\n";

--- a/quickly-configured/benchmark.php
+++ b/quickly-configured/benchmark.php
@@ -61,3 +61,20 @@ for ($j = 0; $j < $runs; $j++) {
 
 echo "\nAVERAGE | MINIMUM | MAXIMUM\n";
 echo (array_sum($times)/count($times)) . " | " . min($times) . " | " . max($times) . "\n";
+
+echo "\nINCLUDING STARTUP TIME\n";
+$times = [];
+for ($j = 0; $j < $runs; $j++) {
+    $start = microtime(true);
+    $adapter = new QuicklyConfiguredAdapter();
+    for ($i = 0; $i < $iterations; $i++) {
+        $object = $adapter->get(F::class);
+        unset($object);
+    }
+    $time = microtime(true) - $start;
+    $times[] = $time;
+    echo "run $j: $time seconds per $iterations\n";
+}
+
+echo "\nAVERAGE | MINIMUM | MAXIMUM\n";
+echo (array_sum($times)/count($times)) . " | " . min($times) . " | " . max($times) . "\n";

--- a/quickly-reflection/benchmark.php
+++ b/quickly-reflection/benchmark.php
@@ -11,9 +11,12 @@ class E { public function __construct(D $d, C $c, B $b) {} }
 class F { public function __construct(E $e, D $d, B $b) {} }
 
 class QuicklyReflectionAdapter {
+    private QuicklyContainer $container;
+    public function __construct() {
+        $this->container = new QuicklyContainer(['DI_USE_REFLECTION' => 'true']);
+    }
     public function get(string $class): object {
-        $container = new QuicklyContainer(['DI_USE_REFLECTION' => 'true']);
-        return $container->get($class);
+        return $this->container->get($class);
     }
 }
 
@@ -23,6 +26,23 @@ $runs = 5;
 $times = [];
 for ($j = 0; $j < $runs; $j++) {
     $start = microtime(true);
+    for ($i = 0; $i < $iterations; $i++) {
+        $object = $adapter->get(F::class);
+        unset($object);
+    }
+    $time = microtime(true) - $start;
+    $times[] = $time;
+    echo "run $j: $time seconds per $iterations\n";
+}
+
+echo "\nAVERAGE | MINIMUM | MAXIMUM\n";
+echo (array_sum($times)/count($times)) . " | " . min($times) . " | " . max($times) . "\n";
+
+echo "\nINCLUDING STARTUP TIME\n";
+$times = [];
+for ($j = 0; $j < $runs; $j++) {
+    $start = microtime(true);
+    $adapter = new QuicklyReflectionAdapter();
     for ($i = 0; $i < $iterations; $i++) {
         $object = $adapter->get(F::class);
         unset($object);

--- a/symfony/benchmark.php
+++ b/symfony/benchmark.php
@@ -62,3 +62,20 @@ for ($j = 0; $j < $runs; $j++) {
 
 echo "\nAVERAGE | MINIMUM | MAXIMUM\n";
 echo (array_sum($times)/count($times)) . " | " . min($times) . " | " . max($times) . "\n";
+
+echo "\nINCLUDING STARTUP TIME\n";
+$times = [];
+for ($j = 0; $j < $runs; $j++) {
+    $start = microtime(true);
+    $adapter = new SymfonyDiAdapter();
+    for ($i = 0; $i < $iterations; $i++) {
+        $object = $adapter->get(F::class);
+        unset($object);
+    }
+    $time = microtime(true) - $start;
+    $times[] = $time;
+    echo "run $j: $time seconds per $iterations\n";
+}
+
+echo "\nAVERAGE | MINIMUM | MAXIMUM\n";
+echo (array_sum($times)/count($times)) . " | " . min($times) . " | " . max($times) . "\n";


### PR DESCRIPTION
## Summary
- add a second benchmark pass that includes container start-up time across all benchmark scripts
- document the new start-up time test in the README

## Testing
- `php benchmark.php | head -n 20` (in `php-di`)
- `php -l php-di/benchmark.php`
- `php -l pimple/benchmark.php`
- `php -l quickly-configured/benchmark.php`
- `php -l quickly-reflection/benchmark.php`
- `php -l symfony/benchmark.php`
- `php -l laravel/benchmark.php`
- `php -l nette-di/benchmark.php`


------
https://chatgpt.com/codex/tasks/task_e_68b88ae6c9b4832f90543508a34ba4e5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Benchmarks now include an additional run that measures performance including container startup time, with per-run and aggregate (average/minimum/maximum) results alongside the existing runtime-only metrics.
  - Improved consistency in the Quickly Reflection benchmark by reusing a persistent container within runs for more representative timings.

- Documentation
  - README updated to clarify that each benchmark reports two test cases: one excluding startup time and one including startup time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->