### PR TITLE
Display benchmark graphs in README summary

### DIFF
--- a/.github/workflows/update-test-results.yml
+++ b/.github/workflows/update-test-results.yml
@@ -42,6 +42,10 @@ jobs:
             echo '| --- | --- | --- | --- |'
             printf "%b" "$summary"
             echo
+            echo '![Speed comparison without startup time](speed_comparison_without_startup.png)'
+            echo
+            echo '![Speed comparison with startup time](speed_comparison_with_startup.png)'
+            echo
             echo '## Test Results'
             echo
             echo 'Results from the latest automated run of the Dockerized benchmarks'

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ This repository benchmarks different dependency injection containers.
 | quickly-reflection | 0.0039896965026855 | 0.0037670135498047 | 0.0047998428344727 |
 | symfony | 0.002692985534668 | 0.0026350021362305 | 0.002830982208252 |
 
+![Speed comparison without startup time](speed_comparison_without_startup.png)
+
+![Speed comparison with startup time](speed_comparison_with_startup.png)
+
 ## Test Results
 
 Results from the latest automated run of the Dockerized benchmarks


### PR DESCRIPTION
## Summary
- show speed comparison graphs in README summary
- update workflow to include graphs when regenerating README

## Testing
- `yamllint -d '{rules: {line-length: {max: 200}}}' .github/workflows/update-test-results.yml`
- `python -m py_compile generate_graphs.py`


------
https://chatgpt.com/codex/tasks/task_e_68b905263bf0832fa4c55cd7379e8638

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added two speed comparison images to the README (with and without startup) after the Summary table to visualize performance.
  * Updated the README generation workflow to include these images automatically.
  * No functional changes to data collection, graph generation, or app behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->