### PR TITLE
Expand benchmarks with 26-class dependency chain across containers

### DIFF
--- a/laravel/benchmark-26.php
+++ b/laravel/benchmark-26.php
@@ -1,0 +1,78 @@
+<?php
+namespace Deep;
+
+require_once 'vendor/autoload.php';
+
+use Illuminate\Container\Container;
+
+class A {}
+class B { public function __construct(A $a) {} }
+class C { public function __construct(B $b) {} }
+class D { public function __construct(C $c) {} }
+class E { public function __construct(D $d) {} }
+class F { public function __construct(E $e) {} }
+class G { public function __construct(F $f) {} }
+class H { public function __construct(G $g) {} }
+class I { public function __construct(H $h) {} }
+class J { public function __construct(I $i) {} }
+class K { public function __construct(J $j) {} }
+class L { public function __construct(K $k) {} }
+class M { public function __construct(L $l) {} }
+class N { public function __construct(M $m) {} }
+class O { public function __construct(N $n) {} }
+class P { public function __construct(O $o) {} }
+class Q { public function __construct(P $p) {} }
+class R { public function __construct(Q $q) {} }
+class S { public function __construct(R $r) {} }
+class T { public function __construct(S $s) {} }
+class U { public function __construct(T $t) {} }
+class V { public function __construct(U $u) {} }
+class W { public function __construct(V $v) {} }
+class X { public function __construct(W $w) {} }
+class Y { public function __construct(X $x) {} }
+class Z { public function __construct(Y $y) {} }
+
+class LaravelDeepAdapter {
+    private Container $container;
+    public function __construct() {
+        $this->container = new Container();
+    }
+    public function get(string $class): object {
+        return $this->container->make($class);
+    }
+}
+
+$adapter = new LaravelDeepAdapter();
+$iterations = 10000;
+$runs = 5;
+$times = [];
+for ($j = 0; $j < $runs; $j++) {
+    $start = microtime(true);
+    for ($i = 0; $i < $iterations; $i++) {
+        $object = $adapter->get(Z::class);
+        unset($object);
+    }
+    $time = microtime(true) - $start;
+    $times[] = $time;
+    echo "run $j: $time seconds per $iterations\n";
+}
+
+echo "\nAVERAGE | MINIMUM | MAXIMUM\n";
+echo (array_sum($times)/count($times)) . " | " . min($times) . " | " . max($times) . "\n";
+
+echo "\nINCLUDING STARTUP TIME\n";
+$times = [];
+for ($j = 0; $j < $runs; $j++) {
+    $start = microtime(true);
+    $adapter = new LaravelDeepAdapter();
+    for ($i = 0; $i < $iterations; $i++) {
+        $object = $adapter->get(Z::class);
+        unset($object);
+    }
+    $time = microtime(true) - $start;
+    $times[] = $time;
+    echo "run $j: $time seconds per $iterations\n";
+}
+
+echo "\nAVERAGE | MINIMUM | MAXIMUM\n";
+echo (array_sum($times)/count($times)) . " | " . min($times) . " | " . max($times) . "\n";

--- a/laravel/benchmark.php
+++ b/laravel/benchmark.php
@@ -54,3 +54,5 @@ for ($j = 0; $j < $runs; $j++) {
 
 echo "\nAVERAGE | MINIMUM | MAXIMUM\n";
 echo (array_sum($times)/count($times)) . " | " . min($times) . " | " . max($times) . "\n";
+
+require __DIR__ . '/benchmark-26.php';

--- a/nette-di/benchmark-26.php
+++ b/nette-di/benchmark-26.php
@@ -1,0 +1,112 @@
+<?php
+namespace Deep;
+
+require_once 'vendor/autoload.php';
+
+use Nette\DI\ContainerLoader;
+use Nette\DI\Compiler;
+
+class A {}
+class B { public function __construct(A $a) {} }
+class C { public function __construct(B $b) {} }
+class D { public function __construct(C $c) {} }
+class E { public function __construct(D $d) {} }
+class F { public function __construct(E $e) {} }
+class G { public function __construct(F $f) {} }
+class H { public function __construct(G $g) {} }
+class I { public function __construct(H $h) {} }
+class J { public function __construct(I $i) {} }
+class K { public function __construct(J $j) {} }
+class L { public function __construct(K $k) {} }
+class M { public function __construct(L $l) {} }
+class N { public function __construct(M $m) {} }
+class O { public function __construct(N $n) {} }
+class P { public function __construct(O $o) {} }
+class Q { public function __construct(P $p) {} }
+class R { public function __construct(Q $q) {} }
+class S { public function __construct(R $r) {} }
+class T { public function __construct(S $s) {} }
+class U { public function __construct(T $t) {} }
+class V { public function __construct(U $u) {} }
+class W { public function __construct(V $v) {} }
+class X { public function __construct(W $w) {} }
+class Y { public function __construct(X $x) {} }
+class Z { public function __construct(Y $y) {} }
+
+class NetteDiDeepAdapter {
+    private \Nette\DI\Container $container;
+    public function __construct() {
+        $loader = new ContainerLoader(sys_get_temp_dir(), true);
+        $class = $loader->load(function (Compiler $compiler) {
+            $compiler->addConfig([
+                'services' => [
+                    A::class,
+                    B::class,
+                    C::class,
+                    D::class,
+                    E::class,
+                    F::class,
+                    G::class,
+                    H::class,
+                    I::class,
+                    J::class,
+                    K::class,
+                    L::class,
+                    M::class,
+                    N::class,
+                    O::class,
+                    P::class,
+                    Q::class,
+                    R::class,
+                    S::class,
+                    T::class,
+                    U::class,
+                    V::class,
+                    W::class,
+                    X::class,
+                    Y::class,
+                    Z::class,
+                ],
+            ]);
+        });
+        $this->container = new $class();
+    }
+    public function get(string $class): object {
+        return $this->container->getByType($class);
+    }
+}
+
+$adapter = new NetteDiDeepAdapter();
+$iterations = 10000;
+$runs = 5;
+$times = [];
+for ($j = 0; $j < $runs; $j++) {
+    $start = microtime(true);
+    for ($i = 0; $i < $iterations; $i++) {
+        $object = $adapter->get(Z::class);
+        unset($object);
+    }
+    $time = microtime(true) - $start;
+    $times[] = $time;
+    echo "run $j: $time seconds per $iterations\n";
+}
+
+echo "\nAVERAGE | MINIMUM | MAXIMUM\n";
+echo (array_sum($times)/count($times)) . " | " . min($times) . " | " . max($times) . "\n";
+
+echo "\nINCLUDING STARTUP TIME\n";
+$times = [];
+for ($j = 0; $j < $runs; $j++) {
+    $start = microtime(true);
+    $adapter = new NetteDiDeepAdapter();
+    for ($i = 0; $i < $iterations; $i++) {
+        $object = $adapter->get(Z::class);
+        unset($object);
+    }
+    $time = microtime(true) - $start;
+    $times[] = $time;
+    echo "run $j: $time seconds per $iterations\n";
+}
+
+echo "\nAVERAGE | MINIMUM | MAXIMUM\n";
+echo (array_sum($times)/count($times)) . " | " . min($times) . " | " . max($times) . "\n";

--- a/nette-di/benchmark.php
+++ b/nette-di/benchmark.php
@@ -68,3 +68,5 @@ for ($j = 0; $j < $runs; $j++) {
 
 echo "\nAVERAGE | MINIMUM | MAXIMUM\n";
 echo (array_sum($times)/count($times)) . " | " . min($times) . " | " . max($times) . "\n";
+
+require __DIR__ . '/benchmark-26.php';

--- a/php-di/benchmark-26.php
+++ b/php-di/benchmark-26.php
@@ -1,0 +1,109 @@
+<?php
+namespace Deep;
+
+require_once 'vendor/autoload.php';
+
+use DI\ContainerBuilder;
+use function DI\create;
+use function DI\get;
+
+class A {}
+class B { public function __construct(A $a) {} }
+class C { public function __construct(B $b) {} }
+class D { public function __construct(C $c) {} }
+class E { public function __construct(D $d) {} }
+class F { public function __construct(E $e) {} }
+class G { public function __construct(F $f) {} }
+class H { public function __construct(G $g) {} }
+class I { public function __construct(H $h) {} }
+class J { public function __construct(I $i) {} }
+class K { public function __construct(J $j) {} }
+class L { public function __construct(K $k) {} }
+class M { public function __construct(L $l) {} }
+class N { public function __construct(M $m) {} }
+class O { public function __construct(N $n) {} }
+class P { public function __construct(O $o) {} }
+class Q { public function __construct(P $p) {} }
+class R { public function __construct(Q $q) {} }
+class S { public function __construct(R $r) {} }
+class T { public function __construct(S $s) {} }
+class U { public function __construct(T $t) {} }
+class V { public function __construct(U $u) {} }
+class W { public function __construct(V $v) {} }
+class X { public function __construct(W $w) {} }
+class Y { public function __construct(X $x) {} }
+class Z { public function __construct(Y $y) {} }
+
+class PhpDiDeepAdapter {
+    private \DI\Container $container;
+    public function __construct() {
+        $builder = new ContainerBuilder();
+        $builder->addDefinitions([
+            A::class => create(),
+            B::class => create()->constructor(get(A::class)),
+            C::class => create()->constructor(get(B::class)),
+            D::class => create()->constructor(get(C::class)),
+            E::class => create()->constructor(get(D::class)),
+            F::class => create()->constructor(get(E::class)),
+            G::class => create()->constructor(get(F::class)),
+            H::class => create()->constructor(get(G::class)),
+            I::class => create()->constructor(get(H::class)),
+            J::class => create()->constructor(get(I::class)),
+            K::class => create()->constructor(get(J::class)),
+            L::class => create()->constructor(get(K::class)),
+            M::class => create()->constructor(get(L::class)),
+            N::class => create()->constructor(get(M::class)),
+            O::class => create()->constructor(get(N::class)),
+            P::class => create()->constructor(get(O::class)),
+            Q::class => create()->constructor(get(P::class)),
+            R::class => create()->constructor(get(Q::class)),
+            S::class => create()->constructor(get(R::class)),
+            T::class => create()->constructor(get(S::class)),
+            U::class => create()->constructor(get(T::class)),
+            V::class => create()->constructor(get(U::class)),
+            W::class => create()->constructor(get(V::class)),
+            X::class => create()->constructor(get(W::class)),
+            Y::class => create()->constructor(get(X::class)),
+            Z::class => create()->constructor(get(Y::class)),
+        ]);
+        $this->container = $builder->build();
+    }
+    public function get(string $class): object {
+        return $this->container->get($class);
+    }
+}
+
+$adapter = new PhpDiDeepAdapter();
+$iterations = 10000;
+$runs = 5;
+$times = [];
+for ($j = 0; $j < $runs; $j++) {
+    $start = microtime(true);
+    for ($i = 0; $i < $iterations; $i++) {
+        $object = $adapter->get(Z::class);
+        unset($object);
+    }
+    $time = microtime(true) - $start;
+    $times[] = $time;
+    echo "run $j: $time seconds per $iterations\n";
+}
+
+echo "\nAVERAGE | MINIMUM | MAXIMUM\n";
+echo (array_sum($times)/count($times)) . " | " . min($times) . " | " . max($times) . "\n";
+
+echo "\nINCLUDING STARTUP TIME\n";
+$times = [];
+for ($j = 0; $j < $runs; $j++) {
+    $start = microtime(true);
+    $adapter = new PhpDiDeepAdapter();
+    for ($i = 0; $i < $iterations; $i++) {
+        $object = $adapter->get(Z::class);
+        unset($object);
+    }
+    $time = microtime(true) - $start;
+    $times[] = $time;
+    echo "run $j: $time seconds per $iterations\n";
+}
+
+echo "\nAVERAGE | MINIMUM | MAXIMUM\n";
+echo (array_sum($times)/count($times)) . " | " . min($times) . " | " . max($times) . "\n";

--- a/php-di/benchmark.php
+++ b/php-di/benchmark.php
@@ -65,3 +65,5 @@ for ($j = 0; $j < $runs; $j++) {
 
 echo "\nAVERAGE | MINIMUM | MAXIMUM\n";
 echo (array_sum($times)/count($times)) . " | " . min($times) . " | " . max($times) . "\n";
+
+require __DIR__ . '/benchmark-26.php';

--- a/pimple/benchmark-26.php
+++ b/pimple/benchmark-26.php
@@ -1,0 +1,105 @@
+<?php
+namespace Deep;
+
+require_once 'vendor/autoload.php';
+
+use Pimple\Container;
+
+class A {}
+class B { public function __construct(A $a) {} }
+class C { public function __construct(B $b) {} }
+class D { public function __construct(C $c) {} }
+class E { public function __construct(D $d) {} }
+class F { public function __construct(E $e) {} }
+class G { public function __construct(F $f) {} }
+class H { public function __construct(G $g) {} }
+class I { public function __construct(H $h) {} }
+class J { public function __construct(I $i) {} }
+class K { public function __construct(J $j) {} }
+class L { public function __construct(K $k) {} }
+class M { public function __construct(L $l) {} }
+class N { public function __construct(M $m) {} }
+class O { public function __construct(N $n) {} }
+class P { public function __construct(O $o) {} }
+class Q { public function __construct(P $p) {} }
+class R { public function __construct(Q $q) {} }
+class S { public function __construct(R $r) {} }
+class T { public function __construct(S $s) {} }
+class U { public function __construct(T $t) {} }
+class V { public function __construct(U $u) {} }
+class W { public function __construct(V $v) {} }
+class X { public function __construct(W $w) {} }
+class Y { public function __construct(X $x) {} }
+class Z { public function __construct(Y $y) {} }
+
+class PimpleDeepAdapter {
+    private Container $container;
+    public function __construct() {
+        $c = new Container();
+        $c[A::class] = $c->factory(fn() => new A());
+        $c[B::class] = $c->factory(fn($c) => new B($c[A::class]));
+        $c[C::class] = $c->factory(fn($c) => new C($c[B::class]));
+        $c[D::class] = $c->factory(fn($c) => new D($c[C::class]));
+        $c[E::class] = $c->factory(fn($c) => new E($c[D::class]));
+        $c[F::class] = $c->factory(fn($c) => new F($c[E::class]));
+        $c[G::class] = $c->factory(fn($c) => new G($c[F::class]));
+        $c[H::class] = $c->factory(fn($c) => new H($c[G::class]));
+        $c[I::class] = $c->factory(fn($c) => new I($c[H::class]));
+        $c[J::class] = $c->factory(fn($c) => new J($c[I::class]));
+        $c[K::class] = $c->factory(fn($c) => new K($c[J::class]));
+        $c[L::class] = $c->factory(fn($c) => new L($c[K::class]));
+        $c[M::class] = $c->factory(fn($c) => new M($c[L::class]));
+        $c[N::class] = $c->factory(fn($c) => new N($c[M::class]));
+        $c[O::class] = $c->factory(fn($c) => new O($c[N::class]));
+        $c[P::class] = $c->factory(fn($c) => new P($c[O::class]));
+        $c[Q::class] = $c->factory(fn($c) => new Q($c[P::class]));
+        $c[R::class] = $c->factory(fn($c) => new R($c[Q::class]));
+        $c[S::class] = $c->factory(fn($c) => new S($c[R::class]));
+        $c[T::class] = $c->factory(fn($c) => new T($c[S::class]));
+        $c[U::class] = $c->factory(fn($c) => new U($c[T::class]));
+        $c[V::class] = $c->factory(fn($c) => new V($c[U::class]));
+        $c[W::class] = $c->factory(fn($c) => new W($c[V::class]));
+        $c[X::class] = $c->factory(fn($c) => new X($c[W::class]));
+        $c[Y::class] = $c->factory(fn($c) => new Y($c[X::class]));
+        $c[Z::class] = $c->factory(fn($c) => new Z($c[Y::class]));
+        $this->container = $c;
+    }
+    public function get(string $class): object {
+        return $this->container[$class];
+    }
+}
+
+$adapter = new PimpleDeepAdapter();
+$iterations = 10000;
+$runs = 5;
+$times = [];
+for ($j = 0; $j < $runs; $j++) {
+    $start = microtime(true);
+    for ($i = 0; $i < $iterations; $i++) {
+        $object = $adapter->get(Z::class);
+        unset($object);
+    }
+    $time = microtime(true) - $start;
+    $times[] = $time;
+    echo "run $j: $time seconds per $iterations\n";
+}
+
+echo "\nAVERAGE | MINIMUM | MAXIMUM\n";
+echo (array_sum($times)/count($times)) . " | " . min($times) . " | " . max($times) . "\n";
+
+echo "\nINCLUDING STARTUP TIME\n";
+$times = [];
+for ($j = 0; $j < $runs; $j++) {
+    $start = microtime(true);
+    $adapter = new PimpleDeepAdapter();
+    for ($i = 0; $i < $iterations; $i++) {
+        $object = $adapter->get(Z::class);
+        unset($object);
+    }
+    $time = microtime(true) - $start;
+    $times[] = $time;
+    echo "run $j: $time seconds per $iterations\n";
+}
+
+echo "\nAVERAGE | MINIMUM | MAXIMUM\n";
+echo (array_sum($times)/count($times)) . " | " . min($times) . " | " . max($times) . "\n";

--- a/pimple/benchmark.php
+++ b/pimple/benchmark.php
@@ -61,3 +61,5 @@ for ($j = 0; $j < $runs; $j++) {
 
 echo "\nAVERAGE | MINIMUM | MAXIMUM\n";
 echo (array_sum($times)/count($times)) . " | " . min($times) . " | " . max($times) . "\n";
+
+require __DIR__ . '/benchmark-26.php';

--- a/quickly-configured/benchmark-26.php
+++ b/quickly-configured/benchmark-26.php
@@ -1,0 +1,106 @@
+<?php
+namespace Deep;
+
+require_once 'vendor/autoload.php';
+
+use Idrinth\Quickly\DependencyInjection\Container as QuicklyContainer;
+use Idrinth\Quickly\DependencyInjection\Definitions\ClassObject;
+
+class A {}
+class B { public function __construct(A $a) {} }
+class C { public function __construct(B $b) {} }
+class D { public function __construct(C $c) {} }
+class E { public function __construct(D $d) {} }
+class F { public function __construct(E $e) {} }
+class G { public function __construct(F $f) {} }
+class H { public function __construct(G $g) {} }
+class I { public function __construct(H $h) {} }
+class J { public function __construct(I $i) {} }
+class K { public function __construct(J $j) {} }
+class L { public function __construct(K $k) {} }
+class M { public function __construct(L $l) {} }
+class N { public function __construct(M $m) {} }
+class O { public function __construct(N $n) {} }
+class P { public function __construct(O $o) {} }
+class Q { public function __construct(P $p) {} }
+class R { public function __construct(Q $q) {} }
+class S { public function __construct(R $r) {} }
+class T { public function __construct(S $s) {} }
+class U { public function __construct(T $t) {} }
+class V { public function __construct(U $u) {} }
+class W { public function __construct(V $v) {} }
+class X { public function __construct(W $w) {} }
+class Y { public function __construct(X $x) {} }
+class Z { public function __construct(Y $y) {} }
+
+class QuicklyConfiguredDeepAdapter {
+    private QuicklyContainer $container;
+    public function __construct() {
+        $this->container = new QuicklyContainer([], constructors: [
+            Z::class => [new ClassObject(Y::class)],
+            Y::class => [new ClassObject(X::class)],
+            X::class => [new ClassObject(W::class)],
+            W::class => [new ClassObject(V::class)],
+            V::class => [new ClassObject(U::class)],
+            U::class => [new ClassObject(T::class)],
+            T::class => [new ClassObject(S::class)],
+            S::class => [new ClassObject(R::class)],
+            R::class => [new ClassObject(Q::class)],
+            Q::class => [new ClassObject(P::class)],
+            P::class => [new ClassObject(O::class)],
+            O::class => [new ClassObject(N::class)],
+            N::class => [new ClassObject(M::class)],
+            M::class => [new ClassObject(L::class)],
+            L::class => [new ClassObject(K::class)],
+            K::class => [new ClassObject(J::class)],
+            J::class => [new ClassObject(I::class)],
+            I::class => [new ClassObject(H::class)],
+            H::class => [new ClassObject(G::class)],
+            G::class => [new ClassObject(F::class)],
+            F::class => [new ClassObject(E::class)],
+            E::class => [new ClassObject(D::class)],
+            D::class => [new ClassObject(C::class)],
+            C::class => [new ClassObject(B::class)],
+            B::class => [new ClassObject(A::class)],
+            A::class => [],
+        ]);
+    }
+    public function get(string $class): object {
+        return $this->container->get($class);
+    }
+}
+
+$adapter = new QuicklyConfiguredDeepAdapter();
+$iterations = 10000;
+$runs = 5;
+$times = [];
+for ($j = 0; $j < $runs; $j++) {
+    $start = microtime(true);
+    for ($i = 0; $i < $iterations; $i++) {
+        $object = $adapter->get(Z::class);
+        unset($object);
+    }
+    $time = microtime(true) - $start;
+    $times[] = $time;
+    echo "run $j: $time seconds per $iterations\n";
+}
+
+echo "\nAVERAGE | MINIMUM | MAXIMUM\n";
+echo (array_sum($times)/count($times)) . " | " . min($times) . " | " . max($times) . "\n";
+
+echo "\nINCLUDING STARTUP TIME\n";
+$times = [];
+for ($j = 0; $j < $runs; $j++) {
+    $start = microtime(true);
+    $adapter = new QuicklyConfiguredDeepAdapter();
+    for ($i = 0; $i < $iterations; $i++) {
+        $object = $adapter->get(Z::class);
+        unset($object);
+    }
+    $time = microtime(true) - $start;
+    $times[] = $time;
+    echo "run $j: $time seconds per $iterations\n";
+}
+
+echo "\nAVERAGE | MINIMUM | MAXIMUM\n";
+echo (array_sum($times)/count($times)) . " | " . min($times) . " | " . max($times) . "\n";

--- a/quickly-configured/benchmark.php
+++ b/quickly-configured/benchmark.php
@@ -61,7 +61,6 @@ for ($j = 0; $j < $runs; $j++) {
 
 echo "\nAVERAGE | MINIMUM | MAXIMUM\n";
 echo (array_sum($times)/count($times)) . " | " . min($times) . " | " . max($times) . "\n";
-
 echo "\nINCLUDING STARTUP TIME\n";
 $times = [];
 for ($j = 0; $j < $runs; $j++) {
@@ -78,3 +77,5 @@ for ($j = 0; $j < $runs; $j++) {
 
 echo "\nAVERAGE | MINIMUM | MAXIMUM\n";
 echo (array_sum($times)/count($times)) . " | " . min($times) . " | " . max($times) . "\n";
+
+require __DIR__ . '/benchmark-26.php';

--- a/quickly-reflection/benchmark-26.php
+++ b/quickly-reflection/benchmark-26.php
@@ -1,0 +1,78 @@
+<?php
+namespace Deep;
+
+require_once 'vendor/autoload.php';
+
+use Idrinth\Quickly\DependencyInjection\Container as QuicklyContainer;
+
+class A {}
+class B { public function __construct(A $a) {} }
+class C { public function __construct(B $b) {} }
+class D { public function __construct(C $c) {} }
+class E { public function __construct(D $d) {} }
+class F { public function __construct(E $e) {} }
+class G { public function __construct(F $f) {} }
+class H { public function __construct(G $g) {} }
+class I { public function __construct(H $h) {} }
+class J { public function __construct(I $i) {} }
+class K { public function __construct(J $j) {} }
+class L { public function __construct(K $k) {} }
+class M { public function __construct(L $l) {} }
+class N { public function __construct(M $m) {} }
+class O { public function __construct(N $n) {} }
+class P { public function __construct(O $o) {} }
+class Q { public function __construct(P $p) {} }
+class R { public function __construct(Q $q) {} }
+class S { public function __construct(R $r) {} }
+class T { public function __construct(S $s) {} }
+class U { public function __construct(T $t) {} }
+class V { public function __construct(U $u) {} }
+class W { public function __construct(V $v) {} }
+class X { public function __construct(W $w) {} }
+class Y { public function __construct(X $x) {} }
+class Z { public function __construct(Y $y) {} }
+
+class QuicklyReflectionDeepAdapter {
+    private QuicklyContainer $container;
+    public function __construct() {
+        $this->container = new QuicklyContainer(['DI_USE_REFLECTION' => 'true']);
+    }
+    public function get(string $class): object {
+        return $this->container->get($class);
+    }
+}
+
+$adapter = new QuicklyReflectionDeepAdapter();
+$iterations = 10000;
+$runs = 5;
+$times = [];
+for ($j = 0; $j < $runs; $j++) {
+    $start = microtime(true);
+    for ($i = 0; $i < $iterations; $i++) {
+        $object = $adapter->get(Z::class);
+        unset($object);
+    }
+    $time = microtime(true) - $start;
+    $times[] = $time;
+    echo "run $j: $time seconds per $iterations\n";
+}
+
+echo "\nAVERAGE | MINIMUM | MAXIMUM\n";
+echo (array_sum($times)/count($times)) . " | " . min($times) . " | " . max($times) . "\n";
+
+echo "\nINCLUDING STARTUP TIME\n";
+$times = [];
+for ($j = 0; $j < $runs; $j++) {
+    $start = microtime(true);
+    $adapter = new QuicklyReflectionDeepAdapter();
+    for ($i = 0; $i < $iterations; $i++) {
+        $object = $adapter->get(Z::class);
+        unset($object);
+    }
+    $time = microtime(true) - $start;
+    $times[] = $time;
+    echo "run $j: $time seconds per $iterations\n";
+}
+
+echo "\nAVERAGE | MINIMUM | MAXIMUM\n";
+echo (array_sum($times)/count($times)) . " | " . min($times) . " | " . max($times) . "\n";

--- a/quickly-reflection/benchmark.php
+++ b/quickly-reflection/benchmark.php
@@ -54,3 +54,5 @@ for ($j = 0; $j < $runs; $j++) {
 
 echo "\nAVERAGE | MINIMUM | MAXIMUM\n";
 echo (array_sum($times)/count($times)) . " | " . min($times) . " | " . max($times) . "\n";
+
+require __DIR__ . '/benchmark-26.php';

--- a/symfony/benchmark-26.php
+++ b/symfony/benchmark-26.php
@@ -1,0 +1,157 @@
+<?php
+namespace Deep;
+
+require_once 'vendor/autoload.php';
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+class A {}
+class B { public function __construct(A $a) {} }
+class C { public function __construct(B $b) {} }
+class D { public function __construct(C $c) {} }
+class E { public function __construct(D $d) {} }
+class F { public function __construct(E $e) {} }
+class G { public function __construct(F $f) {} }
+class H { public function __construct(G $g) {} }
+class I { public function __construct(H $h) {} }
+class J { public function __construct(I $i) {} }
+class K { public function __construct(J $j) {} }
+class L { public function __construct(K $k) {} }
+class M { public function __construct(L $l) {} }
+class N { public function __construct(M $m) {} }
+class O { public function __construct(N $n) {} }
+class P { public function __construct(O $o) {} }
+class Q { public function __construct(P $p) {} }
+class R { public function __construct(Q $q) {} }
+class S { public function __construct(R $r) {} }
+class T { public function __construct(S $s) {} }
+class U { public function __construct(T $t) {} }
+class V { public function __construct(U $u) {} }
+class W { public function __construct(V $v) {} }
+class X { public function __construct(W $w) {} }
+class Y { public function __construct(X $x) {} }
+class Z { public function __construct(Y $y) {} }
+
+class SymfonyDeepAdapter {
+    private ContainerBuilder $container;
+    public function __construct() {
+        $c = new ContainerBuilder();
+        $c->register(A::class, A::class)->setPublic(true);
+        $c->register(B::class, B::class)
+            ->setPublic(true)
+            ->addArgument(new Reference(A::class));
+        $c->register(C::class, C::class)
+            ->setPublic(true)
+            ->addArgument(new Reference(B::class));
+        $c->register(D::class, D::class)
+            ->setPublic(true)
+            ->addArgument(new Reference(C::class));
+        $c->register(E::class, E::class)
+            ->setPublic(true)
+            ->addArgument(new Reference(D::class));
+        $c->register(F::class, F::class)
+            ->setPublic(true)
+            ->addArgument(new Reference(E::class));
+        $c->register(G::class, G::class)
+            ->setPublic(true)
+            ->addArgument(new Reference(F::class));
+        $c->register(H::class, H::class)
+            ->setPublic(true)
+            ->addArgument(new Reference(G::class));
+        $c->register(I::class, I::class)
+            ->setPublic(true)
+            ->addArgument(new Reference(H::class));
+        $c->register(J::class, J::class)
+            ->setPublic(true)
+            ->addArgument(new Reference(I::class));
+        $c->register(K::class, K::class)
+            ->setPublic(true)
+            ->addArgument(new Reference(J::class));
+        $c->register(L::class, L::class)
+            ->setPublic(true)
+            ->addArgument(new Reference(K::class));
+        $c->register(M::class, M::class)
+            ->setPublic(true)
+            ->addArgument(new Reference(L::class));
+        $c->register(N::class, N::class)
+            ->setPublic(true)
+            ->addArgument(new Reference(M::class));
+        $c->register(O::class, O::class)
+            ->setPublic(true)
+            ->addArgument(new Reference(N::class));
+        $c->register(P::class, P::class)
+            ->setPublic(true)
+            ->addArgument(new Reference(O::class));
+        $c->register(Q::class, Q::class)
+            ->setPublic(true)
+            ->addArgument(new Reference(P::class));
+        $c->register(R::class, R::class)
+            ->setPublic(true)
+            ->addArgument(new Reference(Q::class));
+        $c->register(S::class, S::class)
+            ->setPublic(true)
+            ->addArgument(new Reference(R::class));
+        $c->register(T::class, T::class)
+            ->setPublic(true)
+            ->addArgument(new Reference(S::class));
+        $c->register(U::class, U::class)
+            ->setPublic(true)
+            ->addArgument(new Reference(T::class));
+        $c->register(V::class, V::class)
+            ->setPublic(true)
+            ->addArgument(new Reference(U::class));
+        $c->register(W::class, W::class)
+            ->setPublic(true)
+            ->addArgument(new Reference(V::class));
+        $c->register(X::class, X::class)
+            ->setPublic(true)
+            ->addArgument(new Reference(W::class));
+        $c->register(Y::class, Y::class)
+            ->setPublic(true)
+            ->addArgument(new Reference(X::class));
+        $c->register(Z::class, Z::class)
+            ->setPublic(true)
+            ->addArgument(new Reference(Y::class));
+        $c->compile();
+        $this->container = $c;
+    }
+    public function get(string $class): object {
+        return $this->container->get($class);
+    }
+}
+
+$adapter = new SymfonyDeepAdapter();
+$iterations = 10000;
+$runs = 5;
+$times = [];
+for ($j = 0; $j < $runs; $j++) {
+    $start = microtime(true);
+    for ($i = 0; $i < $iterations; $i++) {
+        $object = $adapter->get(Z::class);
+        unset($object);
+    }
+    $time = microtime(true) - $start;
+    $times[] = $time;
+    echo "run $j: $time seconds per $iterations\n";
+}
+
+echo "\nAVERAGE | MINIMUM | MAXIMUM\n";
+echo (array_sum($times)/count($times)) . " | " . min($times) . " | " . max($times) . "\n";
+
+echo "\nINCLUDING STARTUP TIME\n";
+$times = [];
+for ($j = 0; $j < $runs; $j++) {
+    $start = microtime(true);
+    $adapter = new SymfonyDeepAdapter();
+    for ($i = 0; $i < $iterations; $i++) {
+        $object = $adapter->get(Z::class);
+        unset($object);
+    }
+    $time = microtime(true) - $start;
+    $times[] = $time;
+    echo "run $j: $time seconds per $iterations\n";
+}
+
+echo "\nAVERAGE | MINIMUM | MAXIMUM\n";
+echo (array_sum($times)/count($times)) . " | " . min($times) . " | " . max($times) . "\n";

--- a/symfony/benchmark.php
+++ b/symfony/benchmark.php
@@ -79,3 +79,5 @@ for ($j = 0; $j < $runs; $j++) {
 
 echo "\nAVERAGE | MINIMUM | MAXIMUM\n";
 echo (array_sum($times)/count($times)) . " | " . min($times) . " | " . max($times) . "\n";
+
+require __DIR__ . '/benchmark-26.php';


### PR DESCRIPTION
## Summary
- integrate 26-class dependency chain benchmark into each container's main script
- add namespaced deep benchmark files for Laravel, Nette DI, PHP-DI, Pimple, Quickly, and Symfony

## Testing
- `for f in laravel/benchmark.php laravel/benchmark-26.php pimple/benchmark.php pimple/benchmark-26.php php-di/benchmark.php php-di/benchmark-26.php nette-di/benchmark.php nette-di/benchmark-26.php symfony/benchmark.php symfony/benchmark-26.php quickly-configured/benchmark.php quickly-configured/benchmark-26.php quickly-reflection/benchmark.php quickly-reflection/benchmark-26.php; do php -l $f; done`


------
https://chatgpt.com/codex/tasks/task_e_68b9cae1d9b8832fa77b2a2c10161629

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a deep dependency (A–Z) benchmark across Laravel, Nette DI, PHP-DI, Pimple, Quickly (configured and reflection), and Symfony. Outputs per-run timings plus AVERAGE | MINIMUM | MAXIMUM, with and without startup overhead.
- Chores
  - Integrated the new benchmark into existing runners via additional includes to execute the new scenario automatically.
- Style
  - Minor whitespace cleanup in one benchmark script.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->