### PR TITLE
Fix Docker build context in workflow

### DIFF
--- a/.github/workflows/update-test-results.yml
+++ b/.github/workflows/update-test-results.yml
@@ -23,7 +23,8 @@ jobs:
           readarray -t dirs < <(find . -mindepth 3 -maxdepth 3 -name Dockerfile -exec dirname {} \; | sed 's|^\./||' | sort)
           summary=""
           for dir in "${dirs[@]}"; do
-            docker build -t di-benchmark-"$dir" "$dir"
+            docker build -t "di-benchmark-$dir" \
+              -f "$dir/Dockerfile" .
             docker run --rm di-benchmark-"$dir" 2>&1 | tee "$dir".txt
             line=$(tail -n 1 "$dir".txt)
             avg=$(echo "$line" | awk -F'\|' '{print $1}' | tr -d ' ')


### PR DESCRIPTION
## Summary
- ensure Docker images build from repository root so container Dockerfiles can access shared files

## Testing
- `yamllint .github/workflows/update-test-results.yml` *(fails: line-length warnings remain)*
- `docker build -t di-benchmark-test -f containers/pimple/Dockerfile .` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e2176d94832fb2208542e065a533

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow to build Docker images from the repository root while explicitly targeting each module’s Dockerfile, improving reliability of test-result updates across directories.
  * Ensures more consistent test runs in automated pipelines. No changes to application behavior or UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->