### PR TITLE
Install composer in container builds

### DIFF
--- a/containers/laravel/Dockerfile
+++ b/containers/laravel/Dockerfile
@@ -5,6 +5,7 @@ COPY containers/laravel/* ./
 RUN apt-get update \
     && apt-get install -y --no-install-recommends git unzip \
     && rm -rf /var/lib/apt/lists/* \
+    && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
     && composer install --no-interaction --no-progress
 COPY src/*.php ./
 CMD ["php", "benchmark.php"]

--- a/containers/php-di/Dockerfile
+++ b/containers/php-di/Dockerfile
@@ -5,6 +5,7 @@ COPY containers/php-di-build/* ./
 RUN apt-get update \
     && apt-get install -y --no-install-recommends git unzip \
     && rm -rf /var/lib/apt/lists/* \
+    && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
     && composer install --no-interaction --no-progress
 COPY src/*.php ./
 CMD ["php", "benchmark.php"]

--- a/containers/pimple/Dockerfile
+++ b/containers/pimple/Dockerfile
@@ -5,6 +5,7 @@ COPY containers/pimple/* ./
 RUN apt-get update \
     && apt-get install -y --no-install-recommends git unzip \
     && rm -rf /var/lib/apt/lists/* \
+    && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
     && composer install --no-interaction --no-progress
 COPY src/*.php ./
 CMD ["php", "benchmark.php"]

--- a/containers/quickly.configured/Dockerfile
+++ b/containers/quickly.configured/Dockerfile
@@ -5,6 +5,7 @@ COPY containers/quickly-configured/* ./
 RUN apt-get update \
     && apt-get install -y --no-install-recommends git unzip \
     && rm -rf /var/lib/apt/lists/* \
+    && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
     && composer install --no-interaction --no-progress
 COPY src/*.php ./
 CMD ["php", "benchmark.php"]

--- a/containers/quickly.reflection/Dockerfile
+++ b/containers/quickly.reflection/Dockerfile
@@ -5,6 +5,7 @@ COPY containers/quickly-reflection/* ./
 RUN apt-get update \
     && apt-get install -y --no-install-recommends git unzip \
     && rm -rf /var/lib/apt/lists/* \
+    && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
     && composer install --no-interaction --no-progress
 COPY src/*.php ./
 CMD ["php", "benchmark.php"]

--- a/containers/symfony.compiled/Dockerfile
+++ b/containers/symfony.compiled/Dockerfile
@@ -5,6 +5,7 @@ COPY containers/symfony-compiled/* ./
 RUN apt-get update \
     && apt-get install -y --no-install-recommends git unzip \
     && rm -rf /var/lib/apt/lists/* \
+    && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
     && composer install --no-interaction --no-progress
 COPY src/*.php ./
 CMD ["php", "benchmark.php"]


### PR DESCRIPTION
## Summary
- ensure composer is installed before running composer install in all container Dockerfiles

## Testing
- `docker build -f containers/pimple/Dockerfile -t pimple-test .` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68b9eaa964d4832fb52717a5f426596f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Composer installation step to multiple container images (laravel, php-di, pimple, quickly.configured, quickly.reflection, symfony.compiled) to ensure Composer is available during image build.
  * Improves build reliability and consistency by enabling subsequent dependency installation within the containers.
  * No changes to application behavior or public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->