### PR TITLE
Fix folder selection in update-test-results workflow

### DIFF
--- a/.github/workflows/update-test-results.yml
+++ b/.github/workflows/update-test-results.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Build and run benchmarks in Docker
         run: |
           set -euo pipefail
-          readarray -t dirs < <(find containers -mindepth 2 -maxdepth 2 -name Dockerfile -exec dirname {} \; | sed 's|^\./||' | sort)
+          readarray -t dirs < <(find containers -mindepth 2 -maxdepth 2 -name Dockerfile -exec dirname {} \; | sed 's|^containers/||' | sort)
           summary=""
           for dir in "${dirs[@]}"; do
             docker build -t "di-benchmark-$dir" \


### PR DESCRIPTION
## Summary
- ensure workflow strips `containers/` prefix when collecting Dockerfile directories

## Testing
- `yamllint .github/workflows/update-test-results.yml` *(fails: line too long)*

------
https://chatgpt.com/codex/tasks/task_e_68b9fca33c3c832fb919c0e12e467bbf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Improved CI workflow for benchmark builds to handle directory paths correctly, yielding consistent Docker image tags and build paths. Prevents duplicate prefixes and aligns builds with expected directory names. No user-facing changes.
- Tests
  - Benchmark job reliability improved through corrected path handling, reducing build failures and ensuring consistent execution across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->