### PR TITLE
Add development speed check for Symfony container

### DIFF
--- a/containers/symfony.uncompiled/AdapterImplementation.php
+++ b/containers/symfony.uncompiled/AdapterImplementation.php
@@ -1,0 +1,37 @@
+<?php
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+class AdapterImplementation {
+    private ContainerBuilder $container;
+    public function __construct() {
+        $c = new ContainerBuilder();
+        $c->register(A06::class, A06::class)->setPublic(true);
+        $c->register(B06::class, B06::class)
+            ->setPublic(true)
+            ->addArgument(new Reference(A06::class));
+        $c->register(C06::class, C06::class)
+            ->setPublic(true)
+            ->addArgument(new Reference(B06::class));
+        $c->register(D06::class, D06::class)
+            ->setPublic(true)
+            ->addArgument(new Reference(C06::class))
+            ->addArgument(new Reference(B06::class))
+            ->addArgument(new Reference(A06::class));
+        $c->register(E06::class, E06::class)
+            ->setPublic(true)
+            ->addArgument(new Reference(D06::class))
+            ->addArgument(new Reference(C06::class))
+            ->addArgument(new Reference(B06::class));
+        $c->register(F06::class, F06::class)
+            ->setPublic(true)
+            ->addArgument(new Reference(E06::class))
+            ->addArgument(new Reference(D06::class))
+            ->addArgument(new Reference(B06::class));
+        $this->container = $c;
+    }
+    public function get(string $class): object {
+        return $this->container->get($class);
+    }
+}

--- a/containers/symfony.uncompiled/Dockerfile
+++ b/containers/symfony.uncompiled/Dockerfile
@@ -1,0 +1,11 @@
+FROM php:8.4-cli
+
+WORKDIR /app
+COPY containers/symfony.uncompiled/* ./
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git unzip \
+    && rm -rf /var/lib/apt/lists/* \
+    && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
+    && composer install --no-interaction --no-progress
+COPY src/*.php ./
+CMD ["php", "benchmark.php"]

--- a/containers/symfony.uncompiled/composer.json
+++ b/containers/symfony.uncompiled/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "symfony/dependency-injection": "^7.0"
+    }
+}


### PR DESCRIPTION
## Summary
- add an uncompiled Symfony container definition for development-speed benchmarks
- fix Dockerfile to copy its own configuration

## Testing
- `php -l containers/symfony.uncompiled/AdapterImplementation.php`
- `docker build -t di-benchmark-symfony.uncompiled -f containers/symfony.uncompiled/Dockerfile .` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ff75327c832fa8d3240c5f8b6d18

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduces an uncompiled Symfony dependency-injection environment, enabling service resolution and running the benchmark in a containerized runtime.
- Chores
  - Adds required dependency management and Composer setup for the new environment.
  - Provides a Docker image to build and execute the benchmark out of the box.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->