### PR TITLE
Add line break before parentheses in graph labels

### DIFF
--- a/generate_graphs.py
+++ b/generate_graphs.py
@@ -8,7 +8,7 @@ import matplotlib.pyplot as plt
 def format_name(name: str) -> str:
     if "." in name:
         first, rest = name.split(".", 1)
-        return f"{first}({rest})"
+        return f"{first}\n({rest})"
     return name
 
 


### PR DESCRIPTION
## Summary
- Display container names with a line break before parentheses when generating graphs

## Testing
- `python generate_graphs.py` *(fails: No benchmark result files found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba020a213c832f9a37478c1297e48e