### PR TITLE
Parallelize benchmark workflow and aggregate results

### DIFF
--- a/.github/workflows/update-test-results.yml
+++ b/.github/workflows/update-test-results.yml
@@ -1,6 +1,7 @@
+---
 name: Update test results
 
-on:
+'on':
   workflow_dispatch:
   schedule:
     - cron: '0 0 1 * *'
@@ -12,28 +13,61 @@ permissions:
   contents: write
 
 jobs:
-  tests:
+  benchmark:
     if: github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        container:
+          - laravel
+          - nette-di
+          - php-di
+          - pimple
+          - quickly.configured
+          - quickly.reflection
+          - symfony.compiled
+          - symfony.uncompiled
+    steps:
+      - uses: actions/checkout@v5
+      - name: Build and run benchmarks
+        run: |
+          docker build -t di-benchmark-${{ matrix.container }} \
+            -f containers/${{ matrix.container }}/Dockerfile .
+          docker run --rm di-benchmark-${{ matrix.container }} 2>&1 \
+            | tee ${{ matrix.container }}.txt
+      - name: Upload results
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.container }}
+          path: ${{ matrix.container }}.txt
+
+  aggregate:
+    if: github.actor != 'github-actions[bot]'
+    needs: benchmark
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - name: Build and run benchmarks in Docker
+      - name: Download results
+        uses: actions/download-artifact@v4
+        with:
+          pattern: '*'
+          merge-multiple: true
+      - name: Update README
         run: |
           set -euo pipefail
-          readarray -t dirs < <(find containers -mindepth 2 -maxdepth 2 -name Dockerfile -exec dirname {} \; | sed 's|^containers/||' | sort)
+          readarray -t dirs < <(
+            ls *.txt | sed 's/\.txt$//' | sort
+          )
           summary=""
           for dir in "${dirs[@]}"; do
             display_dir="$dir"
             if [[ "$dir" == *.* ]]; then
               display_dir="${dir%%.*}(${dir#*.})"
             fi
-            docker build -t "di-benchmark-$dir" \
-              -f "containers/$dir/Dockerfile" .
-            docker run --rm di-benchmark-"$dir" 2>&1 | tee "$dir".txt
-            line=$(tail -n 1 "$dir".txt)
-            avg=$(echo "$line" | awk -F'\|' '{print $1}' | tr -d ' ')
-            min=$(echo "$line" | awk -F'\|' '{print $2}' | tr -d ' ')
-            max=$(echo "$line" | awk -F'\|' '{print $3}' | tr -d ' ')
+            line=$(tail -n 1 "$dir.txt")
+            avg=$(echo "$line" | awk -F'|' '{print $1}' | tr -d ' ')
+            min=$(echo "$line" | awk -F'|' '{print $2}' | tr -d ' ')
+            max=$(echo "$line" | awk -F'|' '{print $3}' | tr -d ' ')
             summary+="| $display_dir | $avg | $min | $max |\n"
           done
           {
@@ -63,7 +97,7 @@ jobs:
               fi
               echo "### $display_dir"
               echo '```'
-              cat "$dir".txt
+              cat "$dir.txt"
               echo '```'
               echo
             done
@@ -77,7 +111,8 @@ jobs:
           git config --global user.name 'github-actions[bot]'
           git config --global user.email \
             'github-actions[bot]@users.noreply.github.com'
-          git add README.md speed_comparison_without_startup.png speed_comparison_with_startup.png
+          git add README.md speed_comparison_without_startup.png \
+            speed_comparison_with_startup.png
           git commit -m "Update test results" || echo "No changes to commit"
           git push
         env:


### PR DESCRIPTION
## Summary
- run container benchmarks in parallel via matrix jobs
- collect benchmark artifacts and aggregate them to update README and graphs

## Testing
- `yamllint -d '{extends: default, rules: {line-length: disable}}' .github/workflows/update-test-results.yml`


------
https://chatgpt.com/codex/tasks/task_e_68ba09c067f4832f935a5cfdcac8ce41

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - README now includes a benchmark summary table (Average, Minimum, Maximum) and per-implementation result blocks.
- Documentation
  - Added a clearer benchmark section header and structured presentation of results.
- Chores
  - CI revamped to run benchmarks in parallel and aggregate artifacts into the README.
  - Improved reliability by generating README from stored results instead of re-running benchmarks.
  - Adjusted workflow sequencing and triggers for faster, more consistent updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->