### PR TITLE
feat: allow running benchmark tests separately

### DIFF
--- a/src/benchmark.php
+++ b/src/benchmark.php
@@ -7,29 +7,20 @@ require_once __DIR__.'/classes-26.php';
 $iterations = 10000;
 $runs = 10;
 
-function runBenchmark(string $class, int $iterations, int $runs): void {
-    echo "=== Benchmark {$class} ===\n";
-    $adapter = new AdapterImplementation();
+function runBenchmark(string $class, int $iterations, int $runs, bool $includeStartup): void {
+    $label = $includeStartup ? 'including startup time' : 'without startup time';
+    echo "=== Benchmark {$class} {$label} ===\n";
     $times = [];
-    for ($j = 0; $j < $runs; $j++) {
-        $start = microtime(true);
-        for ($i = 0; $i < $iterations; $i++) {
-            $object = $adapter->get($class);
-            unset($object);
-        }
-        $time = microtime(true) - $start;
-        $times[] = $time;
-        echo "run $j: $time seconds per $iterations\n";
+
+    if (!$includeStartup) {
+        $adapter = new AdapterImplementation();
     }
 
-    echo "\nAVERAGE | MINIMUM | MAXIMUM\n";
-    echo (array_sum($times)/count($times)) . " | " . min($times) . " | " . max($times) . "\n";
-
-    echo "\nINCLUDING STARTUP TIME\n";
-    $times = [];
     for ($j = 0; $j < $runs; $j++) {
         $start = microtime(true);
-        $adapter = new AdapterImplementation();
+        if ($includeStartup) {
+            $adapter = new AdapterImplementation();
+        }
         for ($i = 0; $i < $iterations; $i++) {
             $object = $adapter->get($class);
             unset($object);
@@ -43,6 +34,25 @@ function runBenchmark(string $class, int $iterations, int $runs): void {
     echo (array_sum($times)/count($times)) . " | " . min($times) . " | " . max($times) . "\n\n";
 }
 
-runBenchmark(F06::class, $iterations, $runs);
-runBenchmark(Z26::class, $iterations, $runs);
+$tests = [
+    'f06' => [F06::class, false],
+    'f06_startup' => [F06::class, true],
+    'z26' => [Z26::class, false],
+    'z26_startup' => [Z26::class, true],
+];
+
+$selected = $argv[1] ?? null;
+
+if ($selected === null) {
+    foreach ($tests as [$class, $startup]) {
+        runBenchmark($class, $iterations, $runs, $startup);
+    }
+} elseif (isset($tests[$selected])) {
+    [$class, $startup] = $tests[$selected];
+    runBenchmark($class, $iterations, $runs, $startup);
+} else {
+    $available = implode(', ', array_keys($tests));
+    echo "Unknown test '{$selected}'. Available tests: {$available}\n";
+    exit(1);
+}
 


### PR DESCRIPTION
## Summary
- Add CLI selector to `benchmark.php` so individual benchmarks (f06 and z26 with/without startup) can run separately
- Generalize benchmark function to optionally include startup time

## Testing
- `php -l src/benchmark.php`
- `php src/benchmark.php f06` *(fails: Failed to open stream: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ba0d4c96e4832f98c1b604817d7ffe