### PR TITLE
Support JSON benchmark output in workflow

### DIFF
--- a/.github/workflows/update-test-results.yml
+++ b/.github/workflows/update-test-results.yml
@@ -34,12 +34,12 @@ jobs:
           docker build -t di-benchmark-${{ matrix.container }} \
             -f containers/${{ matrix.container }}/Dockerfile .
           docker run --rm di-benchmark-${{ matrix.container }} 2>&1 \
-            | tee ${{ matrix.container }}.txt
+            | tee ${{ matrix.container }}.json
       - name: Upload results
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.container }}
-          path: ${{ matrix.container }}.txt
+          path: ${{ matrix.container }}.json
 
   aggregate:
     if: github.actor != 'github-actions[bot]'
@@ -56,7 +56,7 @@ jobs:
         run: |
           set -euo pipefail
           readarray -t dirs < <(
-            ls *.txt | sed 's/\.txt$//' | sort
+            ls *.json | sed 's/\.json$//' | sort
           )
           summary=""
           for dir in "${dirs[@]}"; do
@@ -64,10 +64,9 @@ jobs:
             if [[ "$dir" == *.* ]]; then
               display_dir="${dir%%.*}(${dir#*.})"
             fi
-            line=$(tail -n 1 "$dir.txt")
-            avg=$(echo "$line" | awk -F'|' '{print $1}' | tr -d ' ')
-            min=$(echo "$line" | awk -F'|' '{print $2}' | tr -d ' ')
-            max=$(echo "$line" | awk -F'|' '{print $3}' | tr -d ' ')
+            avg=$(jq -r '.z26_startup.average' "$dir.json")
+            min=$(jq -r '.z26_startup.min' "$dir.json")
+            max=$(jq -r '.z26_startup.max' "$dir.json")
             summary+="| $display_dir | $avg | $min | $max |\n"
           done
           {
@@ -100,8 +99,8 @@ jobs:
                 display_dir="${dir%%.*}(${dir#*.})"
               fi
               echo "### $display_dir"
-              echo '```'
-              cat "$dir.txt"
+              echo '```json'
+              cat "$dir.json"
               echo '```'
               echo
             done
@@ -114,7 +113,7 @@ jobs:
         run: |
           set -euo pipefail
           readarray -t dirs < <(
-            ls *.txt | sed 's/\.txt$//' | sort
+            ls *.json | sed 's/\.json$//' | sort
           )
           php_version=$(php -v | head -n1 | awk '{print $2}')
           date=$(date -u +%Y-%m-%d)
@@ -131,10 +130,9 @@ jobs:
             done
             echo "results:"
             for dir in "${dirs[@]}"; do
-              line=$(tail -n 1 "$dir.txt")
-              avg=$(echo "$line" | awk -F'|' '{print $1}' | tr -d ' ')
-              min=$(echo "$line" | awk -F'|' '{print $2}' | tr -d ' ')
-              max=$(echo "$line" | awk -F'|' '{print $3}' | tr -d ' ')
+              avg=$(jq -r '.z26_startup.average' "$dir.json")
+              min=$(jq -r '.z26_startup.min' "$dir.json")
+              max=$(jq -r '.z26_startup.max' "$dir.json")
               echo "  $dir:"
               echo "    average: $avg"
               echo "    minimum: $min"

--- a/generate_graphs.py
+++ b/generate_graphs.py
@@ -1,6 +1,6 @@
 import glob
+import json
 import os
-import re
 
 import matplotlib.pyplot as plt
 
@@ -13,28 +13,21 @@ def format_name(name: str) -> str:
 
 
 containers = sorted(
-    os.path.splitext(os.path.basename(f))[0] for f in glob.glob("*.txt")
+    os.path.splitext(os.path.basename(f))[0] for f in glob.glob("*.json")
 )
 if not containers:
     raise RuntimeError("No benchmark result files found")
 display_names = [format_name(c) for c in containers]
 
 def extract_averages(filename):
-    values = []
-    pattern = re.compile(r"^[0-9.]+ \| [0-9.]+ \| [0-9.]+$")
     with open(filename) as f:
-        for line in f:
-            line = line.strip()
-            if pattern.match(line):
-                values.append(float(line.split('|')[0]))
-    if len(values) < 2:
-        raise ValueError(f"Expected two average lines in {filename}")
-    return values[0], values[1]
+        data = json.load(f)
+    return data["z26"]["average"], data["z26_startup"]["average"]
 
 without_startup = []
 with_startup = []
 for container in containers:
-    wos, ws = extract_averages(f"{container}.txt")
+    wos, ws = extract_averages(f"{container}.json")
     without_startup.append(wos)
     with_startup.append(ws)
 


### PR DESCRIPTION
## Summary
- capture benchmark results as JSON artifacts and parse them with jq
- update graph generation to read benchmark JSON data

## Testing
- `python3 -m py_compile generate_graphs.py`
- `yamllint .github/workflows/update-test-results.yml`


------
https://chatgpt.com/codex/tasks/task_e_68ba0fc70e88832fb33da8a5a7b0f02b