### PR TITLE
Limit archive commits to scheduled runs

### DIFF
--- a/.github/workflows/update-test-results.yml
+++ b/.github/workflows/update-test-results.yml
@@ -131,7 +131,10 @@ jobs:
               echo "    minimum: $min"
               echo "    maximum: $max"
             done
-          } | tee run_summary.yaml "archive/$date.yaml"
+          } | tee run_summary.yaml
+          if [[ "$GITHUB_EVENT_NAME" == "schedule" ]]; then
+            cp run_summary.yaml "archive/$date.yaml"
+          fi
       - name: Generate README
         run: php generate_readme.php
       - name: Commit results
@@ -140,7 +143,10 @@ jobs:
           git config --global user.email \
             'github-actions[bot]@users.noreply.github.com'
           git add README.md speed_comparison_without_startup.png \
-            speed_comparison_with_startup.png run_summary.yaml archive
+            speed_comparison_with_startup.png run_summary.yaml
+          if [ "$GITHUB_EVENT_NAME" = "schedule" ]; then
+            git add archive
+          fi
           git commit -m "Update test results" || echo "No changes to commit"
           git push
         env:


### PR DESCRIPTION
## Summary
- Archive run summaries only when workflow is triggered by schedule
- Only commit archive directory for scheduled runs

## Testing
- `yamllint .github/workflows/update-test-results.yml`


------
https://chatgpt.com/codex/tasks/task_e_68ba1940130c832faf876948f7b7b31a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * CI workflow now always generates a run_summary.yaml for every run.
  * Archival of dated results occurs only on scheduled runs; non-scheduled runs no longer update the archive.
  * Commit step conditionally includes the archive directory only for scheduled events.
  * Reduces unnecessary repository changes from manual/PR runs and provides a cleaner history with a predictable archiving cadence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->