### PR TITLE
Add Laminas ServiceManager container

### DIFF
--- a/containers/laminas-servicemanager/AdapterImplementation.php
+++ b/containers/laminas-servicemanager/AdapterImplementation.php
@@ -1,0 +1,18 @@
+<?php
+
+use Laminas\ServiceManager\ServiceManager;
+use Laminas\ServiceManager\AbstractFactory\ReflectionBasedAbstractFactory;
+
+class AdapterImplementation {
+    private ServiceManager $container;
+    public function __construct() {
+        $this->container = new ServiceManager([
+            'abstract_factories' => [
+                ReflectionBasedAbstractFactory::class,
+            ],
+        ]);
+    }
+    public function get(string $class): object {
+        return $this->container->get($class);
+    }
+}

--- a/containers/laminas-servicemanager/Dockerfile
+++ b/containers/laminas-servicemanager/Dockerfile
@@ -1,0 +1,11 @@
+FROM php:8.4-cli
+
+WORKDIR /app
+COPY containers/laminas-servicemanager/* ./
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git unzip \
+    && rm -rf /var/lib/apt/lists/* \
+    && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
+    && composer install --no-interaction --no-progress
+COPY src/*.php ./
+CMD ["php", "benchmark.php"]

--- a/containers/laminas-servicemanager/composer.json
+++ b/containers/laminas-servicemanager/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "laminas/laminas-servicemanager": "^3.21"
+    }
+}


### PR DESCRIPTION
## Summary
- add Laminas ServiceManager container implementation
- set up composer dependency and Dockerfile for container benchmarking

## Testing
- `composer install`
- `php benchmark.php f06`


------
https://chatgpt.com/codex/tasks/task_e_68ba1b8ef82c832fbedcc2e63f2ed896