### PR TITLE
Cancel in-progress workflow runs

### DIFF
--- a/.github/workflows/update-test-results.yml
+++ b/.github/workflows/update-test-results.yml
@@ -12,6 +12,10 @@ name: Update test results
 permissions:
   contents: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     if: github.actor != 'github-actions[bot]'


### PR DESCRIPTION
## Summary
- ensure old workflow runs are automatically canceled

## Testing
- `yamllint .github/workflows/update-test-results.yml`


------
https://chatgpt.com/codex/tasks/task_e_68ba1cd92490832f8e28781e6bea73c7