### PR TITLE
Add league/container benchmark

### DIFF
--- a/containers/league-container/AdapterImplementation.php
+++ b/containers/league-container/AdapterImplementation.php
@@ -1,0 +1,16 @@
+<?php
+
+use League\Container\Container;
+use League\Container\ReflectionContainer;
+
+class AdapterImplementation {
+    private Container $container;
+    public function __construct() {
+        $c = new Container();
+        $c->delegate(new ReflectionContainer());
+        $this->container = $c;
+    }
+    public function get(string $class): object {
+        return $this->container->get($class);
+    }
+}

--- a/containers/league-container/Dockerfile
+++ b/containers/league-container/Dockerfile
@@ -1,0 +1,11 @@
+FROM php:8.4-cli
+
+WORKDIR /app
+COPY containers/league-container/* ./
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git unzip \
+    && rm -rf /var/lib/apt/lists/* \
+    && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
+    && composer install --no-interaction --no-progress
+COPY src/*.php ./
+CMD ["php", "benchmark.php"]

--- a/containers/league-container/composer.json
+++ b/containers/league-container/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "league/container": "^5.1"
+    }
+}


### PR DESCRIPTION
## Summary
- add league/container as a new container option using ReflectionContainer for auto-wiring
- include Dockerfile and Composer configuration for league/container benchmarks

## Testing
- `php -l containers/league-container/AdapterImplementation.php`
- `composer validate --no-check-publish` (in containers/league-container)
- `composer install --no-interaction --no-progress` (in containers/league-container)


------
https://chatgpt.com/codex/tasks/task_e_68ba1bce9508832f9b7437059c790b81