### PR TITLE
Add Dice container for benchmarking

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ Tested with PHP 8.4.12.
 - **symfony(uncompiled)**
   - `symfony/dependency-injection`: `^7.0`
 
+- **dice**
+  - `level-2/dice`: `^4.0`
+
 ## Summary
 
 | Container | Average | Minimum | Maximum |
@@ -42,6 +45,7 @@ Tested with PHP 8.4.12.
 | quickly(reflection) | 0.0038904190063477 | 0.0038211345672607 | 0.0040030479431152 |
 | symfony(compiled) | 0.0026464939117432 | 0.0025930404663086 | 0.0027880668640137 |
 | symfony(uncompiled) | 0.0020638227462769 | 0.0020380020141602 | 0.0020980834960938 |
+| dice | 0 | 0 | 0 |
 
 ![Speed comparison without startup time](speed_comparison_without_startup.png)
 

--- a/containers/dice/AdapterImplementation.php
+++ b/containers/dice/AdapterImplementation.php
@@ -1,0 +1,13 @@
+<?php
+
+use Dice\Dice;
+
+class AdapterImplementation {
+    private Dice $container;
+    public function __construct() {
+        $this->container = new Dice();
+    }
+    public function get(string $class): object {
+        return $this->container->create($class);
+    }
+}

--- a/containers/dice/Dockerfile
+++ b/containers/dice/Dockerfile
@@ -1,0 +1,11 @@
+FROM php:8.4-cli
+
+WORKDIR /app
+COPY containers/dice/* ./
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git unzip \
+    && rm -rf /var/lib/apt/lists/* \
+    && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
+    && composer install --no-interaction --no-progress
+COPY src/*.php ./
+CMD ["php", "benchmark.php"]

--- a/containers/dice/composer.json
+++ b/containers/dice/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "level-2/dice": "^4.0"
+    }
+}

--- a/run_summary.yaml
+++ b/run_summary.yaml
@@ -16,6 +16,8 @@ dependency_versions:
     symfony/dependency-injection: "^7.0"
   symfony.uncompiled:
     symfony/dependency-injection: "^7.0"
+  dice:
+    level-2/dice: "^4.0"
 results:
   laravel:
     average: 0.62267036437988
@@ -49,3 +51,7 @@ results:
     average: 0.0020638227462769
     minimum: 0.0020380020141602
     maximum: 0.0020980834960938
+  dice:
+    average: 0
+    minimum: 0
+    maximum: 0


### PR DESCRIPTION
## Summary
- add Dice dependency injection container support
- document Dice dependency and placeholder results

## Testing
- ⚠️ `php benchmark.php z26` (failed: benchmark execution exceeded environment limits)


------
https://chatgpt.com/codex/tasks/task_e_68ba1b9e5000832fb99e28080c5328cd