### PR TITLE
Run workflow only on PHP or JSON changes

### DIFF
--- a/.github/workflows/update-test-results.yml
+++ b/.github/workflows/update-test-results.yml
@@ -8,6 +8,9 @@ name: Update test results
   push:
     branches:
       - the-one
+    paths:
+      - '**/*.php'
+      - '**/*.json'
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
- only trigger workflow on push when PHP or JSON files change

## Testing
- `yamllint -v .github/workflows/update-test-results.yml`


------
https://chatgpt.com/codex/tasks/task_e_68ba1ec871ac832f934397a1d81eb080