### PR TITLE
Add JSON merge utility to avoid stray numerical errors

### DIFF
--- a/.github/workflows/update-test-results.yml
+++ b/.github/workflows/update-test-results.yml
@@ -154,20 +154,11 @@ jobs:
           for container in "${containers[@]}"; do
             readarray -t tests < <(ls "${container}"-*-*.json | cut -d'-' -f2 | sort -u)
             for test in "${tests[@]}"; do
-              jq -s --arg test "$test" '
-                {
-                  ($test): {
-                    class: .[0][$test].class,
-                    include_startup: .[0][$test].include_startup,
-                    runs: [.[].[$test].runs[]],
-                    average: ([.[].[$test].runs[]] | add / length),
-                    min: ([.[].[$test].runs[]] | min),
-                    max: ([.[].[$test].runs[]] | max)
-                  }
-                }
-              ' "${container}-${test}-"*.json
-            done | jq -s 'add' > "${container}.json"
-            rm "${container}"-*-*.json
+              php merge_json.php "${container}-${test}.json" "${container}-${test}-"*.json
+              rm "${container}-${test}-"*.json
+            done
+            php merge_json.php "${container}.json" "${container}-"*.json
+            rm "${container}-"*.json
           done
       - name: Generate graphs
         run: php generate_graphs.php

--- a/merge_json.php
+++ b/merge_json.php
@@ -1,0 +1,46 @@
+<?php
+function merge_json_files(array $files): array {
+    $merged = [];
+    foreach ($files as $file) {
+        $contents = file_get_contents($file);
+        $data = json_decode($contents, true);
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            throw new RuntimeException("Error decoding {$file}: " . json_last_error_msg());
+        }
+        if (!is_array($data)) {
+            throw new RuntimeException("JSON in {$file} does not decode to array");
+        }
+        foreach ($data as $test => $result) {
+            if (!isset($merged[$test])) {
+                $merged[$test] = $result;
+                continue;
+            }
+            if (!isset($result['runs']) || !is_array($result['runs'])) {
+                throw new RuntimeException("Missing runs array for {$test} in {$file}");
+            }
+            $merged[$test]['runs'] = array_merge($merged[$test]['runs'], $result['runs']);
+        }
+    }
+    foreach ($merged as $test => &$result) {
+        if (isset($result['runs']) && is_array($result['runs'])) {
+            $runs = $result['runs'];
+            $result['average'] = array_sum($runs) / count($runs);
+            $result['min'] = min($runs);
+            $result['max'] = max($runs);
+        }
+    }
+    unset($result);
+    return $merged;
+}
+
+if ($argc < 3) {
+    fwrite(STDERR, "Usage: php merge_json.php output.json input1.json [input2.json ...]\n");
+    exit(1);
+}
+
+$output = $argv[1];
+$inputs = array_slice($argv, 2);
+
+$merged = merge_json_files($inputs);
+file_put_contents($output, json_encode($merged, JSON_PRETTY_PRINT));
+


### PR DESCRIPTION
## Summary
- drop jq aggregation and rely on PHP merge script in workflow
- extend merge_json.php to combine run arrays and recompute metrics

## Testing
- `php -l merge_json.php`


------
https://chatgpt.com/codex/tasks/task_e_68ba409dad2c832fba14c9f0cc1e62c1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - More accurate test result aggregation with computed averages, minimums, and maximums reflected in reports and graphs.
- Tests
  - Introduced a utility to merge per-test run outputs into consolidated results, improving reliability of test metrics.
- Chores
  - Updated CI workflow to replace jq-based aggregation with a more robust merging approach, generating per-test and per-container summaries and cleaning up intermediate files to streamline the pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->