### PR TITLE
Skip invalid JSON when merging

### DIFF
--- a/merge_json.php
+++ b/merge_json.php
@@ -8,10 +8,12 @@ function merge_json_files(array $files): array {
         $contents = file_get_contents($file);
         $data = json_decode($contents, true);
         if (json_last_error() !== JSON_ERROR_NONE) {
-            throw new RuntimeException("Error decoding {$file}: " . json_last_error_msg());
+            fwrite(STDERR, "Warning: Error decoding {$file}: " . json_last_error_msg() . "\n");
+            continue;
         }
         if (!is_array($data)) {
-            throw new RuntimeException("JSON in {$file} does not decode to array");
+            fwrite(STDERR, "Warning: JSON in {$file} does not decode to array\n");
+            continue;
         }
         foreach ($data as $test => $result) {
             if (!isset($merged[$test])) {
@@ -19,7 +21,8 @@ function merge_json_files(array $files): array {
                 continue;
             }
             if (!isset($result['runs']) || !is_array($result['runs'])) {
-                throw new RuntimeException("Missing runs array for {$test} in {$file}");
+                fwrite(STDERR, "Warning: Missing runs array for {$test} in {$file}\n");
+                continue;
             }
             $merged[$test]['runs'] = array_merge($merged[$test]['runs'], $result['runs']);
         }


### PR DESCRIPTION
## Summary
- avoid runtime errors by skipping unreadable JSON files
- guard against missing run data when merging results

## Testing
- `php -l merge_json.php`


------
https://chatgpt.com/codex/tasks/task_e_68bac16f6858832fba9c6f5d5d7514f4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of the JSON merge tool: it no longer aborts on malformed input. JSON decode errors, non-array JSON, or entries with invalid runs now emit warnings to STDERR and are skipped, while valid data continues to be processed. Output format and computed statistics for valid inputs remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->