### PR TITLE
Add progress output to benchmark script

### DIFF
--- a/src/benchmark.php
+++ b/src/benchmark.php
@@ -25,7 +25,10 @@ function runBenchmark(string $class, int $iterations, int $runs, bool $includeSt
             unset($object);
         }
         $times[] = microtime(true) - $start;
+        fwrite(STDERR, '.');
     }
+
+    fwrite(STDERR, ' ' . $j . '/' . $runs . PHP_EOL);
 
     return [
         'class' => $class,
@@ -51,10 +54,12 @@ $results = [];
 
 if ($selected === null) {
     foreach ($tests as $name => [$class, $startup]) {
+        fwrite(STDERR, 'Running ' . $name . ': ');
         $results[$name] = runBenchmark($class, $iterations, $runs, $startup);
     }
 } elseif (isset($tests[$selected])) {
     [$class, $startup] = $tests[$selected];
+    fwrite(STDERR, 'Running ' . $selected . ': ');
     $results[$selected] = runBenchmark($class, $iterations, $runs, $startup);
 } else {
     $available = implode(', ', array_keys($tests));


### PR DESCRIPTION
## Summary
- show progress for each benchmark run using dots and final counts without affecting JSON parsing
- display which test is currently running via STDERR

## Testing
- `php -l src/benchmark.php`


------
https://chatgpt.com/codex/tasks/task_e_68bac658ffc8832f9e669ef4a55207c0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added real-time progress indicators during benchmarks: a dot per iteration and a “currentRun / totalRuns” line after each test run (written to STDERR).
  * Display test-name banners when running tests in bulk or a selected test: “Running <name>: ” before execution (to STDERR).
  * Machine-readable JSON output to STDOUT remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->