### PR TITLE
Fix run summary generation for dash-named containers

### DIFF
--- a/.github/workflows/update-test-results.yml
+++ b/.github/workflows/update-test-results.yml
@@ -244,9 +244,9 @@ jobs:
             - name: Merge test results
               run: |
                   set -euo pipefail
-                  readarray -t containers < <(ls *-*-*.json | cut -d'-' -f1 | sort -u)
+                  readarray -t containers < <(ls *-*-*.json | sed 's/-[^-]*-[^-]*\.json$//' | sort -u)
                   for container in "${containers[@]}"; do
-                      readarray -t tests < <(ls "${container}"-*-*.json | cut -d'-' -f2 | sort -u)
+                      readarray -t tests < <(ls "${container}"-*-*.json | sed -E "s/^${container}-([^-]+)-[^-]+\.json$/\1/" | sort -u)
                       for test in "${tests[@]}"; do
                           php merge_json.php "${container}-${test}.json" "${container}-${test}-"*.json
                           rm "${container}-${test}-"*.json
@@ -257,41 +257,7 @@ jobs:
             - name: Generate graphs
               run: php generate_graphs.php
             - name: Generate run summary
-              run: |
-                  set -euo pipefail
-                  readarray -t dirs < <(
-                      ls *.json | sed 's/\.json$//' | sort
-                  )
-                  php_version=$(php -v | head -n1 | awk '{print $2}')
-                  date=$(date -u +%Y-%m-%d)
-                  mkdir -p archive
-                  {
-                      echo "php_version: \"${php_version}\""
-                      echo "dependency_versions:"
-                      for dir in "${dirs[@]}"; do
-                          comp_file="containers/$dir/composer.json"
-                          package=$(jq -r '.require | to_entries[0].key' "$comp_file")
-                          version=$(jq -r '.require | to_entries[0].value' "$comp_file")
-                          echo "  $dir:"
-                          echo "    $package: \"$version\""
-                      done
-                      echo "results:"
-                      for dir in "${dirs[@]}"; do
-                          echo "  $dir:"
-                          for test in f06 f06_startup p16 p16_startup z26 z26_startup; do
-                              avg=$(jq -r ".${test}.average // 0" "$dir.json")
-                              min=$(jq -r ".${test}.min // 0" "$dir.json")
-                              max=$(jq -r ".${test}.max // 0" "$dir.json")
-                              echo "    ${test}:"
-                              echo "      average: $avg"
-                              echo "      minimum: $min"
-                              echo "      maximum: $max"
-                          done
-                      done
-                  } | tee run_summary.yaml
-                  if [[ "$GITHUB_EVENT_NAME" == "schedule" ]]; then
-                      cp run_summary.yaml "archive/$date.yaml"
-                  fi
+              run: php generate_run_summary.pho
             - name: Generate README
               run: php generate_readme.php
             - name: Commit results

--- a/generate_run_summary.pho
+++ b/generate_run_summary.pho
@@ -1,0 +1,71 @@
+<?php
+$files = glob('*.json');
+sort($files);
+$dirs = array_map(fn($f) => pathinfo($f, PATHINFO_FILENAME), $files);
+
+$phpVersion = PHP_VERSION;
+$date = (new DateTime('now', new DateTimeZone('UTC')))->format('Y-m-d');
+
+$depVersions = [];
+foreach ($dirs as $dir) {
+    $compFile = "containers/{$dir}/composer.json";
+    if (!file_exists($compFile)) {
+        continue;
+    }
+    $compData = json_decode(file_get_contents($compFile), true);
+    if (!is_array($compData['require'] ?? null)) {
+        continue;
+    }
+    $firstDep = array_slice($compData['require'], 0, 1, true);
+    foreach ($firstDep as $package => $version) {
+        $depVersions[$dir][$package] = $version;
+    }
+}
+
+$tests = ['f06', 'f06_startup', 'p16', 'p16_startup', 'z26', 'z26_startup'];
+$results = [];
+foreach ($dirs as $dir) {
+    $jsonFile = "{$dir}.json";
+    if (!file_exists($jsonFile)) {
+        continue;
+    }
+    $data = json_decode(file_get_contents($jsonFile), true);
+    foreach ($tests as $test) {
+        $avg = $data[$test]['average'] ?? 0;
+        $min = $data[$test]['min'] ?? 0;
+        $max = $data[$test]['max'] ?? 0;
+        $results[$dir][$test] = [
+            'average' => $avg,
+            'minimum' => $min,
+            'maximum' => $max,
+        ];
+    }
+}
+
+$lines = [];
+$lines[] = 'php_version: "' . $phpVersion . '"';
+$lines[] = 'dependency_versions:';
+foreach ($depVersions as $dir => $deps) {
+    $lines[] = '  ' . $dir . ':';
+    foreach ($deps as $package => $version) {
+        $lines[] = '    ' . $package . ': "' . $version . '"';
+    }
+}
+$lines[] = 'results:';
+foreach ($results as $dir => $testsData) {
+    $lines[] = '  ' . $dir . ':';
+    foreach ($testsData as $test => $stats) {
+        $lines[] = '    ' . $test . ':';
+        $lines[] = '      average: ' . $stats['average'];
+        $lines[] = '      minimum: ' . $stats['minimum'];
+        $lines[] = '      maximum: ' . $stats['maximum'];
+    }
+}
+file_put_contents('run_summary.yaml', implode("\n", $lines) . "\n");
+
+if (getenv('GITHUB_EVENT_NAME') === 'schedule') {
+    if (!is_dir('archive')) {
+        mkdir('archive', 0777, true);
+    }
+    copy('run_summary.yaml', 'archive/' . $date . '.yaml');
+}


### PR DESCRIPTION
## Summary
- parse container names without truncating dashes in workflow aggregation
- move run summary generation to `generate_run_summary.pho`

## Testing
- `php -l generate_run_summary.pho`


------
https://chatgpt.com/codex/tasks/task_e_68baede29e28832f9cad1a16016063f1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic generation of a run summary YAML artifact with average/min/max metrics per container and test.
  * Scheduled workflows now archive each run’s summary by date for easier historical tracking.

* **Improvements**
  * More reliable detection of containers and tests from result files, improving accuracy when names contain dashes.
  * Consolidated summary creation into a single step for consistency; downstream graphing and result publication remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->