### PR TITLE
refactor: move json merging into php

### DIFF
--- a/.github/workflows/update-test-results.yml
+++ b/.github/workflows/update-test-results.yml
@@ -242,18 +242,7 @@ jobs:
                   pattern: 'result-*-*-*'
                   merge-multiple: true
             - name: Merge test results
-              run: |
-                  set -euo pipefail
-                  readarray -t containers < <(ls *-*-*.json | sed 's/-[^-]*-[^-]*\.json$//' | sort -u)
-                  for container in "${containers[@]}"; do
-                      readarray -t tests < <(ls "${container}"-*-*.json | sed -E "s/^${container}-([^-]+)-[^-]+\.json$/\1/" | sort -u)
-                      for test in "${tests[@]}"; do
-                          php merge_json.php "${container}-${test}.json" "${container}-${test}-"*.json
-                          rm "${container}-${test}-"*.json
-                      done
-                      php merge_json.php "${container}.json" "${container}-"*.json
-                      rm "${container}-"*.json
-                  done
+              run: php merge_json.php
             - name: Generate graphs
               run: php generate_graphs.php
             - name: Generate run summary

--- a/merge_json.php
+++ b/merge_json.php
@@ -39,14 +39,42 @@ function merge_json_files(array $files): array {
     return $merged;
 }
 
-if ($argc < 3) {
-    fwrite(STDERR, "Usage: php merge_json.php output.json input1.json [input2.json ...]\n");
-    exit(1);
+if ($argc > 2) {
+    $output = $argv[1];
+    $inputs = array_slice($argv, 2);
+    $merged = merge_json_files($inputs);
+    file_put_contents($output, json_encode($merged, JSON_PRETTY_PRINT));
+    return;
 }
 
-$output = $argv[1];
-$inputs = array_slice($argv, 2);
+$runFiles = glob('*-*-*.json');
+if (!$runFiles) {
+    return;
+}
 
-$merged = merge_json_files($inputs);
-file_put_contents($output, json_encode($merged, JSON_PRETTY_PRINT));
+$containers = [];
+foreach ($runFiles as $file) {
+    if (!preg_match('/^(.+)-([^-]+)-[^-]+\.json$/', $file, $matches)) {
+        continue;
+    }
+    $container = $matches[1];
+    $test = $matches[2];
+    $containers[$container][$test][] = $file;
+}
+
+foreach ($containers as $container => $tests) {
+    foreach ($tests as $test => $files) {
+        $merged = merge_json_files($files);
+        file_put_contents("{$container}-{$test}.json", json_encode($merged, JSON_PRETTY_PRINT));
+        foreach ($files as $f) {
+            unlink($f);
+        }
+    }
+    $testFiles = glob("{$container}-*.json");
+    $mergedContainer = merge_json_files($testFiles);
+    file_put_contents("{$container}.json", json_encode($mergedContainer, JSON_PRETTY_PRINT));
+    foreach ($testFiles as $f) {
+        unlink($f);
+    }
+}
 


### PR DESCRIPTION
## Summary
- merge per-test and per-container JSON results directly in PHP
- simplify test workflow to call new PHP merging logic

## Testing
- `php -l merge_json.php`


------
https://chatgpt.com/codex/tasks/task_e_68bb0d3afa58832f811c053c71b43941

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined CI step to merge test results with a single command.
  * Automatic discovery and aggregation of test result files.
  * Generates per-test and per-container summary outputs with pretty-printed JSON.
  * Performs cleanup of intermediate files and skips work when no inputs are found.

* **Tests**
  * More consistent and reliable merged test summaries.
  * Slightly faster and simpler test result processing in CI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->