### PR TITLE
Disable validation for configured Quickly container

### DIFF
--- a/containers/quickly.configured/AdapterImplementation.php
+++ b/containers/quickly.configured/AdapterImplementation.php
@@ -6,7 +6,7 @@ use Idrinth\Quickly\DependencyInjection\Definitions\ClassObject;
 class AdapterImplementation {
     private QuicklyContainer $container;
     public function __construct() {
-        $this->container = new QuicklyContainer([], constructors: [
+        $this->container = new QuicklyContainer(['DI_USE_CONFIG_VALIDATION' => 'false'], constructors: [
             F06::class => [
                 new ClassObject(E06::class),
                 new ClassObject(D06::class),


### PR DESCRIPTION
## Summary
- disable configuration validation for pre-built Quickly container by setting `DI_USE_CONFIG_VALIDATION` to `false`

## Testing
- `php -l containers/quickly.configured/AdapterImplementation.php`


------
https://chatgpt.com/codex/tasks/task_e_68bb0da06134832fbef2aa312acd8491

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved issues where configuration validation could block or slow application startup in certain environments.
* **Chores**
  * Adjusted container initialization settings to reduce unnecessary configuration checks, improving startup reliability and consistency across deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->