### PR TITLE
Persist benchmark results to /out directory

### DIFF
--- a/containers/aura-di/Dockerfile
+++ b/containers/aura-di/Dockerfile
@@ -1,6 +1,7 @@
 FROM php:8.4-cli
 
 WORKDIR /app
+RUN mkdir /out
 COPY containers/aura-di/* ./
 RUN apt-get update \
     && apt-get install -y --no-install-recommends git unzip \

--- a/containers/auryn/Dockerfile
+++ b/containers/auryn/Dockerfile
@@ -1,6 +1,7 @@
 FROM php:8.4-cli
 
 WORKDIR /app
+RUN mkdir /out
 COPY containers/auryn/* ./
 RUN apt-get update \
     && apt-get install -y --no-install-recommends git unzip \

--- a/containers/dice/Dockerfile
+++ b/containers/dice/Dockerfile
@@ -1,6 +1,7 @@
 FROM php:8.4-cli
 
 WORKDIR /app
+RUN mkdir /out
 COPY containers/dice/* ./
 RUN apt-get update \
     && apt-get install -y --no-install-recommends git unzip \

--- a/containers/laminas-servicemanager/Dockerfile
+++ b/containers/laminas-servicemanager/Dockerfile
@@ -1,6 +1,7 @@
 FROM php:8.4-cli
 
 WORKDIR /app
+RUN mkdir /out
 COPY containers/laminas-servicemanager/* ./
 RUN apt-get update \
     && apt-get install -y --no-install-recommends git unzip \

--- a/containers/laravel.singletons/Dockerfile
+++ b/containers/laravel.singletons/Dockerfile
@@ -1,6 +1,7 @@
 FROM php:8.4-cli
 
 WORKDIR /app
+RUN mkdir /out
 COPY containers/laravel.singletons/* ./
 RUN apt-get update \
     && apt-get install -y --no-install-recommends git unzip \

--- a/containers/laravel.unconfigured/Dockerfile
+++ b/containers/laravel.unconfigured/Dockerfile
@@ -1,6 +1,7 @@
 FROM php:8.4-cli
 
 WORKDIR /app
+RUN mkdir /out
 COPY containers/laravel.unconfigured/* ./
 RUN apt-get update \
     && apt-get install -y --no-install-recommends git unzip \

--- a/containers/league-container/Dockerfile
+++ b/containers/league-container/Dockerfile
@@ -1,6 +1,7 @@
 FROM php:8.4-cli
 
 WORKDIR /app
+RUN mkdir /out
 COPY containers/league-container/* ./
 RUN apt-get update \
     && apt-get install -y --no-install-recommends git unzip \

--- a/containers/nette-di/Dockerfile
+++ b/containers/nette-di/Dockerfile
@@ -1,6 +1,7 @@
 FROM php:8.4-cli
 
 WORKDIR /app
+RUN mkdir /out
 COPY containers/nette-di/* ./
 RUN apt-get update \
     && apt-get install -y --no-install-recommends git unzip \

--- a/containers/phalcon/Dockerfile
+++ b/containers/phalcon/Dockerfile
@@ -1,6 +1,7 @@
 FROM php:8.4-cli
 
 WORKDIR /app
+RUN mkdir /out
 COPY containers/phalcon/* ./
 RUN apt-get update \
     && apt-get install -y --no-install-recommends git unzip \

--- a/containers/php-di/Dockerfile
+++ b/containers/php-di/Dockerfile
@@ -1,6 +1,7 @@
 FROM php:8.4-cli
 
 WORKDIR /app
+RUN mkdir /out
 COPY containers/php-di/* ./
 RUN apt-get update \
     && apt-get install -y --no-install-recommends git unzip \

--- a/containers/pimple/Dockerfile
+++ b/containers/pimple/Dockerfile
@@ -1,6 +1,7 @@
 FROM php:8.4-cli
 
 WORKDIR /app
+RUN mkdir /out
 COPY containers/pimple/* ./
 RUN apt-get update \
     && apt-get install -y --no-install-recommends git unzip \

--- a/containers/quickly.configured/Dockerfile
+++ b/containers/quickly.configured/Dockerfile
@@ -1,6 +1,7 @@
 FROM php:8.4-cli
 
 WORKDIR /app
+RUN mkdir /out
 COPY containers/quickly.configured/* ./
 RUN apt-get update \
     && apt-get install -y --no-install-recommends git unzip \

--- a/containers/quickly.reflection/Dockerfile
+++ b/containers/quickly.reflection/Dockerfile
@@ -1,6 +1,7 @@
 FROM php:8.4-cli
 
 WORKDIR /app
+RUN mkdir /out
 COPY containers/quickly.reflection/* ./
 RUN apt-get update \
     && apt-get install -y --no-install-recommends git unzip \

--- a/containers/symfony.compiled/Dockerfile
+++ b/containers/symfony.compiled/Dockerfile
@@ -1,6 +1,7 @@
 FROM php:8.4-cli
 
 WORKDIR /app
+RUN mkdir /out
 COPY containers/symfony.compiled/* ./
 RUN apt-get update \
     && apt-get install -y --no-install-recommends git unzip \

--- a/src/benchmark.php
+++ b/src/benchmark.php
@@ -67,5 +67,11 @@ if ($selected === null) {
     exit(1);
 }
 
-echo json_encode($results, JSON_PRETTY_PRINT) . PHP_EOL;
+$outputDir = '/out';
+if (!is_dir($outputDir)) {
+    mkdir($outputDir, 0777, true);
+}
+$file = $outputDir . '/results.json';
+file_put_contents($file, json_encode($results, JSON_PRETTY_PRINT) . PHP_EOL);
+fwrite(STDERR, 'Results written to ' . $file . PHP_EOL);
 


### PR DESCRIPTION
## Summary
- Write benchmark results to `/out/results.json` instead of stdout
- Ensure each container image creates `/out` directory for result files

## Testing
- `php -l src/benchmark.php`


------
https://chatgpt.com/codex/tasks/task_e_68bb2ca7cb0c832fa44ffcc24d9143e8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Benchmark results are now saved as pretty-printed JSON to /out/results.json inside the container. Results are no longer printed to STDOUT; a message with the file path is emitted.
* **Chores**
  * All benchmark containers now pre-create the /out directory during build to standardize output handling across images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->