### PR TITLE
Mount out volume for benchmark results

### DIFF
--- a/.github/workflows/update-test-results.yml
+++ b/.github/workflows/update-test-results.yml
@@ -89,9 +89,9 @@ jobs:
               run: docker load -i di-benchmark-${{ matrix.container }}.tar
             - name: Run benchmarks
               run: |
-                  docker run --rm di-benchmark-${{ matrix.container }} \
-                      php benchmark.php ${{ matrix.test }} 10 2>&1 \
-                      | tee ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
+                  docker run --rm -v "$PWD:/out" di-benchmark-${{ matrix.container }} \
+                      php benchmark.php ${{ matrix.test }} 10 2>&1
+                  mv results.json ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
             - name: Upload results
               uses: actions/upload-artifact@v4
               with:
@@ -128,9 +128,9 @@ jobs:
               run: docker load -i di-benchmark-${{ matrix.container }}.tar
             - name: Run benchmarks
               run: |
-                  docker run --rm di-benchmark-${{ matrix.container }} \
-                      php benchmark.php ${{ matrix.test }} 5 2>&1 \
-                      | tee ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
+                  docker run --rm -v "$PWD:/out" di-benchmark-${{ matrix.container }} \
+                      php benchmark.php ${{ matrix.test }} 5 2>&1
+                  mv results.json ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
             - name: Upload results
               uses: actions/upload-artifact@v4
               with:
@@ -175,9 +175,9 @@ jobs:
               run: docker load -i di-benchmark-${{ matrix.container }}.tar
             - name: Run benchmarks
               run: |
-                  docker run --rm di-benchmark-${{ matrix.container }} \
-                      php benchmark.php ${{ matrix.test }} 1 2>&1 \
-                      | tee ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
+                  docker run --rm -v "$PWD:/out" di-benchmark-${{ matrix.container }} \
+                      php benchmark.php ${{ matrix.test }} 1 2>&1
+                  mv results.json ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
             - name: Upload results
               uses: actions/upload-artifact@v4
               with:
@@ -217,9 +217,9 @@ jobs:
               run: docker load -i di-benchmark-${{ matrix.container }}.tar
             - name: Run benchmarks
               run: |
-                  docker run --rm di-benchmark-${{ matrix.container }} \
-                      php benchmark.php ${{ matrix.test }} 1 2>&1 \
-                      | tee ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
+                  docker run --rm -v "$PWD:/out" di-benchmark-${{ matrix.container }} \
+                      php benchmark.php ${{ matrix.test }} 1 2>&1
+                  mv results.json ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
             - name: Upload results
               uses: actions/upload-artifact@v4
               with:


### PR DESCRIPTION
## Summary
- map host workspace to /out in docker benchmark runs so result JSON files persist

## Testing
- `php -l src/benchmark.php`

------
https://chatgpt.com/codex/tasks/task_e_68bb2de21bc0832f8b17da5a687f2e09