### PR TITLE
Fix workflow to use correct tool script paths

### DIFF
--- a/.github/workflows/update-test-results.yml
+++ b/.github/workflows/update-test-results.yml
@@ -242,13 +242,13 @@ jobs:
                   pattern: 'result-*-*-*'
                   merge-multiple: true
             - name: Merge test results
-              run: php merge_json.php
+              run: php tools/merge_json.php
             - name: Generate graphs
-              run: php generate_graphs.php
+              run: php tools/generate_graphs.php
             - name: Generate run summary
-              run: php generate_run_summary.php
+              run: php tools/generate_run_summary.php
             - name: Generate README
-              run: php generate_readme.php
+              run: php tools/generate_readme.php
             - name: Commit results
               run: |
                   git config --global user.name 'github-actions[bot]'


### PR DESCRIPTION
## Summary
- ensure GitHub Actions workflow invokes tool scripts from the `tools` directory

## Testing
- `php -l tools/merge_json.php`
- `php -l tools/generate_graphs.php`
- `php -l tools/generate_run_summary.php`
- `php -l tools/generate_readme.php`


------
https://chatgpt.com/codex/tasks/task_e_68bb30882e4c832fa2e5b4978ef14e63