### PR TITLE
Ensure tool scripts operate from project root

### DIFF
--- a/tools/generate_graphs.php
+++ b/tools/generate_graphs.php
@@ -1,4 +1,7 @@
 <?php
+
+chdir(__DIR__ . '/..');
+
 function format_name(string $name): string {
     if (strpos($name, '.') !== false) {
         [$first, $rest] = explode('.', $name, 2);

--- a/tools/generate_readme.php
+++ b/tools/generate_readme.php
@@ -1,4 +1,7 @@
 <?php
+
+chdir(__DIR__ . '/..');
+
 function parse_simple_yaml(string $filename): array {
     $lines = file($filename, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
     $data = [];

--- a/tools/generate_run_summary.php
+++ b/tools/generate_run_summary.php
@@ -1,4 +1,7 @@
 <?php
+
+chdir(__DIR__ . '/..');
+
 $files = glob('*.json');
 sort($files);
 $dirs = array_map(fn($f) => pathinfo($f, PATHINFO_FILENAME), $files);

--- a/tools/merge_json.php
+++ b/tools/merge_json.php
@@ -1,4 +1,7 @@
 <?php
+
+chdir(__DIR__ . '/..');
+
 function merge_json_files(array $files): array {
     $merged = [];
     foreach ($files as $file) {


### PR DESCRIPTION
## Summary
- Ensure all tools use the repository root for file operations by changing directory to the project base

## Testing
- `php -l tools/generate_graphs.php`
- `php -l tools/generate_readme.php`
- `php -l tools/generate_run_summary.php`
- `php -l tools/merge_json.php`


------
https://chatgpt.com/codex/tasks/task_e_68bb30a3f468832fa2a351862981d877