### PR TITLE
Ensure workflow commits all generated graph images

### DIFF
--- a/.github/workflows/update-test-results.yml
+++ b/.github/workflows/update-test-results.yml
@@ -254,8 +254,7 @@ jobs:
                   git config --global user.name 'github-actions[bot]'
                   git config --global user.email \
                       'github-actions[bot]@users.noreply.github.com'
-                  git add README.md speed_comparison_without_startup.png \
-                      speed_comparison_with_startup.png run_summary.yaml
+                  git add README.md speed_comparison_*.png run_summary.yaml
                   if [ "$GITHUB_EVENT_NAME" = "schedule" ]; then
                       git add archive
                   fi


### PR DESCRIPTION
## Summary
- update workflow to add all speed comparison graphs when committing results

## Testing
- `php -l tools/generate_graphs.php`


------
https://chatgpt.com/codex/tasks/task_e_68bb45a0bbf4832f813993d9cd152ac1