### PR TITLE
fix: derive PHP version from Dockerfiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository benchmarks different dependency injection containers.
 
-Tested with PHP 8.3.6.
+Tested with PHP 8.4.
 
 ## Dependency Versions
 

--- a/run_summary.yaml
+++ b/run_summary.yaml
@@ -1,4 +1,4 @@
-php_version: "8.3.6"
+php_version: "8.4"
 dependency_versions:
   aura-di:
     aura/di: "^5.0"

--- a/tools/generate_run_summary.php
+++ b/tools/generate_run_summary.php
@@ -6,7 +6,17 @@ $files = glob('*.json');
 sort($files);
 $dirs = array_map(fn($f) => pathinfo($f, PATHINFO_FILENAME), $files);
 
-$phpVersion = PHP_VERSION;
+// determine PHP version from container Dockerfiles
+$phpVersion = 'unknown';
+$dockerFiles = glob('containers/*/Dockerfile');
+sort($dockerFiles);
+foreach ($dockerFiles as $dockerFile) {
+    $firstLine = trim(file($dockerFile)[0] ?? '');
+    if (preg_match('/FROM\s+php:([^\s]+)/i', $firstLine, $matches)) {
+        $phpVersion = str_replace('-cli', '', $matches[1]);
+        break;
+    }
+}
 $date = (new DateTime('now', new DateTimeZone('UTC')))->format('Y-m-d');
 
 $depVersions = [];


### PR DESCRIPTION
## Summary
- determine PHP version by scanning container Dockerfiles
- update run summary and README to use Dockerfile PHP version

## Testing
- `php -l tools/generate_run_summary.php`
- `php tools/generate_readme.php`


------
https://chatgpt.com/codex/tasks/task_e_68bb4d979118832fa477bebf3aa2959e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Documentation
  * Updated README to indicate PHP 8.4 as the tested environment.

* Chores
  * Implemented automated detection of the PHP version used by containers so run summaries reflect the actual environment consistently.
  * Regenerated the run summary to align with the detected version (now showing PHP 8.4).

* Notes
  * No user-facing behavior changes or public API modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->