### PR TITLE
Add percentage labels to benchmark graphs

### DIFF
--- a/tools/generate_graphs.php
+++ b/tools/generate_graphs.php
@@ -85,6 +85,12 @@ function create_bar_chart(array $values, string $title, string $filename, array 
         $x2 = $x1 + $barWidth;
         $y2 = $topMargin + $plotHeight;
         imagefilledrectangle($img, $x1, $y1, $x2, $y2, $blue);
+        $percentage = ($logVal / $maxLog) * 100;
+        $percentageText = sprintf('%.1f%%', $percentage);
+        $percentageWidth = imagefontwidth(2) * strlen($percentageText);
+        $percentageX = $x1 + ($barWidth - $percentageWidth) / 2;
+        $percentageY = $y1 - imagefontheight(2) - 2;
+        imagestring($img, 2, $percentageX, $percentageY, $percentageText, $black);
         $labelLines = explode("\n", $labels[$i]);
         $labelY = $topMargin + $plotHeight + 5;
         foreach ($labelLines as $line) {


### PR DESCRIPTION
## Summary
- Display the duration percentage above each bar in generated benchmark charts
- Remove generated PNG assets from commit history to avoid tracking binaries

## Testing
- `php -l tools/generate_graphs.php`
- `php tools/generate_graphs.php` *(fails: No benchmark result files found)*

------
https://chatgpt.com/codex/tasks/task_e_68bbbd45c740832fae523412eb34bee6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Bar charts now display percentage labels above each bar, showing each value as a percentage of the chart’s maximum.
  - Labels are centered horizontally and positioned just above the bars for improved readability and quick comparison.
  - Labels appear only when valid data is present to ensure meaningful output.
  - Existing chart appearance and behavior remain unchanged aside from the added labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->