### PR TITLE
docs: clarify binary files should not be committed

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,7 @@ This repository contains PHP benchmark code. These instructions help maintain co
 ## General Guidelines
 - Use four spaces for indentation.
 - Ensure files end with a newline.
+- Do not commit binary files such as images; generate them as needed outside of version control.
 
 ## Testing
 - When modifying PHP source files, run `php -l` on each changed file to verify syntax.


### PR DESCRIPTION
## Summary
- document that binary files like images shouldn't be committed and should remain out of version control

## Testing
- No tests were run; no PHP files were modified

------
https://chatgpt.com/codex/tasks/task_e_68bbbed73894832f85e3f6391ed57806