### PR TITLE
docs: add disclaimer about quickly container

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This repository benchmarks different dependency injection containers.
 
+The "quickly" container is maintained by the same author as this benchmark, and the results may be unconsciously biased.
+
 ## Environment
 
 | Component | Version |

--- a/tools/generate_readme.php
+++ b/tools/generate_readme.php
@@ -78,6 +78,8 @@ $lines[] = '# PHP Dependency Injection Benchmark';
 $lines[] = '';
 $lines[] = 'This repository benchmarks different dependency injection containers.';
 $lines[] = '';
+$lines[] = 'The "quickly" container is maintained by the same author as this benchmark, and the results may be unconsciously biased.';
+$lines[] = '';
 $depVersions = $data['dependency_versions'] ?? [];
 if (!empty($data['php_version'])) {
     $lines[] = '## Environment';


### PR DESCRIPTION
## Summary
- note shared authorship between benchmark and `quickly`
- clarify that results may be unconsciously biased

## Testing
- `php -l tools/generate_readme.php`
- `php tools/generate_readme.php` *(deprecated float-to-int conversion warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68bdb396277c832fb8b5ab62ab1650c2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Added a bias disclaimer to the README and generated documentation, noting that the “quickly” container is maintained by the benchmark author and results may be unconsciously biased.
  - Improves transparency and context for interpreting benchmark results.
  - No functional or API changes; no runtime impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->