### PR TITLE
Add configured Dice benchmark

### DIFF
--- a/containers/dice.configured/AdapterImplementation.php
+++ b/containers/dice.configured/AdapterImplementation.php
@@ -1,0 +1,70 @@
+<?php
+
+use Dice\Dice;
+use Dice\Instance;
+
+class AdapterImplementation {
+    private Dice $container;
+    public function __construct() {
+        $this->container = new Dice();
+        $definitions = [
+            F06::class => [E06::class, D06::class, B06::class],
+            E06::class => [D06::class, C06::class, B06::class],
+            D06::class => [C06::class, B06::class, A06::class],
+            C06::class => [B06::class],
+            B06::class => [A06::class],
+            A06::class => [],
+            P16::class => [O16::class, N16::class, M16::class],
+            O16::class => [N16::class, M16::class],
+            N16::class => [M16::class, L16::class, K16::class],
+            M16::class => [L16::class, K16::class],
+            L16::class => [K16::class],
+            K16::class => [J16::class, I16::class, H16::class],
+            J16::class => [I16::class, H16::class],
+            I16::class => [H16::class, G16::class, F16::class],
+            H16::class => [G16::class, F16::class],
+            G16::class => [F16::class],
+            F16::class => [E16::class, D16::class, B16::class],
+            E16::class => [D16::class, C16::class],
+            D16::class => [C16::class, B16::class, A16::class],
+            C16::class => [B16::class],
+            B16::class => [A16::class],
+            A16::class => [],
+            Z26::class => [Y26::class, X26::class, W26::class, V26::class, U26::class],
+            Y26::class => [X26::class, W26::class, V26::class, U26::class],
+            X26::class => [W26::class, V26::class, U26::class],
+            W26::class => [V26::class, U26::class],
+            V26::class => [U26::class],
+            U26::class => [T26::class, S26::class, R26::class, Q26::class, P26::class],
+            T26::class => [S26::class, R26::class, Q26::class, P26::class],
+            S26::class => [R26::class, Q26::class, P26::class],
+            R26::class => [Q26::class, P26::class],
+            Q26::class => [P26::class, O26::class, N26::class, M26::class, L26::class],
+            P26::class => [O26::class, N26::class, M26::class, L26::class],
+            O26::class => [N26::class, M26::class, L26::class],
+            N26::class => [M26::class, L26::class],
+            M26::class => [L26::class, K26::class, J26::class, I26::class, H26::class],
+            L26::class => [K26::class, J26::class, I26::class, H26::class, G26::class],
+            K26::class => [J26::class, I26::class, H26::class, G26::class, F26::class],
+            J26::class => [I26::class, H26::class, G26::class, F26::class],
+            I26::class => [H26::class, G26::class, F26::class],
+            H26::class => [G26::class, F26::class],
+            G26::class => [F26::class],
+            F26::class => [E26::class, D26::class, B26::class],
+            E26::class => [D26::class, C26::class],
+            D26::class => [C26::class, B26::class, A26::class],
+            C26::class => [B26::class],
+            B26::class => [A26::class],
+            A26::class => [],
+        ];
+        foreach ($definitions as $class => $deps) {
+            $this->container->addRule(
+                $class,
+                ['constructParams' => array_map(fn($d) => new Instance($d), $deps)]
+            );
+        }
+    }
+    public function get(string $class): object {
+        return $this->container->create($class);
+    }
+}

--- a/containers/dice.configured/Dockerfile
+++ b/containers/dice.configured/Dockerfile
@@ -1,0 +1,12 @@
+FROM php:8.4-cli
+
+WORKDIR /app
+RUN mkdir /out
+COPY containers/dice.configured/* ./
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git unzip \
+    && rm -rf /var/lib/apt/lists/* \
+    && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
+    && composer install --no-interaction --no-progress
+COPY src/*.php ./
+CMD ["php", "benchmark.php"]

--- a/containers/dice.configured/composer.json
+++ b/containers/dice.configured/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "level-2/dice": "^4.0"
+    }
+}


### PR DESCRIPTION
## Summary
- add configured Dice container with explicit constructor rules for benchmark graphs

## Testing
- `php -l containers/dice.configured/AdapterImplementation.php`
- `php tools/merge_json.php`
- `php tools/generate_run_summary.php`
- `php tools/generate_graphs.php`
- `php tools/generate_readme.php` *(deprecated float to int warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68bdb44177ec832f94f9de05b89bdc93

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a preconfigured dependency injection container to resolve and return class instances at runtime.

- Chores
  - Added a Dockerfile to build a PHP CLI image and execute project benchmarks.
  - Introduced a Composer manifest to manage external dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->