### PR TITLE
Add classmap to quickly configured

### DIFF
--- a/containers/quickly.configured/composer.json
+++ b/containers/quickly.configured/composer.json
@@ -1,5 +1,12 @@
 {
     "require": {
         "idrinth/quickly": "dev-master"
+    },
+    "autoload": {
+        "classmap": [
+            "classes-06.php",
+            "classes-16.php",
+            "classes-26.php"
+        ]
     }
 }


### PR DESCRIPTION
## Summary
- add classmap autoload configuration to Quickly configured's composer.json

## Testing
- `php -l containers/quickly.configured/AdapterImplementation.php`


------
https://chatgpt.com/codex/tasks/task_e_68bdb8b890bc832f9b06df06d917be76