### PR TITLE
Add cached Laravel and predefined League container variants

### DIFF
--- a/containers/laravel.cached/AdapterImplementation.php
+++ b/containers/laravel.cached/AdapterImplementation.php
@@ -1,0 +1,73 @@
+<?php
+
+use Illuminate\Container\Container;
+
+class AdapterImplementation {
+    private Container $container;
+    public function __construct() {
+        $c = new Container();
+        $definitions = [
+            F06::class => [E06::class, D06::class, B06::class],
+            E06::class => [D06::class, C06::class, B06::class],
+            D06::class => [C06::class, B06::class, A06::class],
+            C06::class => [B06::class],
+            B06::class => [A06::class],
+            A06::class => [],
+            P16::class => [O16::class, N16::class, M16::class],
+            O16::class => [N16::class, M16::class],
+            N16::class => [M16::class, L16::class, K16::class],
+            M16::class => [L16::class, K16::class],
+            L16::class => [K16::class],
+            K16::class => [J16::class, I16::class, H16::class],
+            J16::class => [I16::class, H16::class],
+            I16::class => [H16::class, G16::class, F16::class],
+            H16::class => [G16::class, F16::class],
+            G16::class => [F16::class],
+            F16::class => [E16::class, D16::class, B16::class],
+            E16::class => [D16::class, C16::class],
+            D16::class => [C16::class, B16::class, A16::class],
+            C16::class => [B16::class],
+            B16::class => [A16::class],
+            A16::class => [],
+            Z26::class => [Y26::class, X26::class, W26::class, V26::class, U26::class],
+            Y26::class => [X26::class, W26::class, V26::class, U26::class],
+            X26::class => [W26::class, V26::class, U26::class],
+            W26::class => [V26::class, U26::class],
+            V26::class => [U26::class],
+            U26::class => [T26::class, S26::class, R26::class, Q26::class, P26::class],
+            T26::class => [S26::class, R26::class, Q26::class, P26::class],
+            S26::class => [R26::class, Q26::class, P26::class],
+            R26::class => [Q26::class, P26::class],
+            Q26::class => [P26::class, O26::class, N26::class, M26::class, L26::class],
+            P26::class => [O26::class, N26::class, M26::class, L26::class],
+            O26::class => [N26::class, M26::class, L26::class],
+            N26::class => [M26::class, L26::class],
+            M26::class => [L26::class, K26::class, J26::class, I26::class, H26::class],
+            L26::class => [K26::class, J26::class, I26::class, H26::class, G26::class],
+            K26::class => [J26::class, I26::class, H26::class, G26::class, F26::class],
+            J26::class => [I26::class, H26::class, G26::class, F26::class],
+            I26::class => [H26::class, G26::class, F26::class],
+            H26::class => [G26::class, F26::class],
+            G26::class => [F26::class],
+            F26::class => [E26::class, D26::class, B26::class],
+            E26::class => [D26::class, C26::class],
+            D26::class => [C26::class, B26::class, A26::class],
+            C26::class => [B26::class],
+            B26::class => [A26::class],
+            A26::class => [],
+        ];
+        foreach ($definitions as $class => $deps) {
+            $c->bind($class, function ($c) use ($class, $deps) {
+                $args = [];
+                foreach ($deps as $dep) {
+                    $args[] = $c->make($dep);
+                }
+                return new $class(...$args);
+            });
+        }
+        $this->container = $c;
+    }
+    public function get(string $class): object {
+        return $this->container->make($class);
+    }
+}

--- a/containers/laravel.cached/Dockerfile
+++ b/containers/laravel.cached/Dockerfile
@@ -1,0 +1,12 @@
+FROM php:8.4-cli
+
+WORKDIR /app
+RUN mkdir /out
+COPY containers/laravel.cached/* ./
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git unzip \
+    && rm -rf /var/lib/apt/lists/* \
+    && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
+    && composer install --no-interaction --no-progress
+COPY src/*.php ./
+CMD ["php", "benchmark.php"]

--- a/containers/laravel.cached/composer.json
+++ b/containers/laravel.cached/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "illuminate/container": "^12.28"
+    }
+}

--- a/containers/league.predefined/AdapterImplementation.php
+++ b/containers/league.predefined/AdapterImplementation.php
@@ -1,0 +1,70 @@
+<?php
+
+use League\Container\Container;
+
+class AdapterImplementation {
+    private Container $container;
+    public function __construct() {
+        $c = new Container();
+        $definitions = [
+            F06::class => [E06::class, D06::class, B06::class],
+            E06::class => [D06::class, C06::class, B06::class],
+            D06::class => [C06::class, B06::class, A06::class],
+            C06::class => [B06::class],
+            B06::class => [A06::class],
+            A06::class => [],
+            P16::class => [O16::class, N16::class, M16::class],
+            O16::class => [N16::class, M16::class],
+            N16::class => [M16::class, L16::class, K16::class],
+            M16::class => [L16::class, K16::class],
+            L16::class => [K16::class],
+            K16::class => [J16::class, I16::class, H16::class],
+            J16::class => [I16::class, H16::class],
+            I16::class => [H16::class, G16::class, F16::class],
+            H16::class => [G16::class, F16::class],
+            G16::class => [F16::class],
+            F16::class => [E16::class, D16::class, B16::class],
+            E16::class => [D16::class, C16::class],
+            D16::class => [C16::class, B16::class, A16::class],
+            C16::class => [B16::class],
+            B16::class => [A16::class],
+            A16::class => [],
+            Z26::class => [Y26::class, X26::class, W26::class, V26::class, U26::class],
+            Y26::class => [X26::class, W26::class, V26::class, U26::class],
+            X26::class => [W26::class, V26::class, U26::class],
+            W26::class => [V26::class, U26::class],
+            V26::class => [U26::class],
+            U26::class => [T26::class, S26::class, R26::class, Q26::class, P26::class],
+            T26::class => [S26::class, R26::class, Q26::class, P26::class],
+            S26::class => [R26::class, Q26::class, P26::class],
+            R26::class => [Q26::class, P26::class],
+            Q26::class => [P26::class, O26::class, N26::class, M26::class, L26::class],
+            P26::class => [O26::class, N26::class, M26::class, L26::class],
+            O26::class => [N26::class, M26::class, L26::class],
+            N26::class => [M26::class, L26::class],
+            M26::class => [L26::class, K26::class, J26::class, I26::class, H26::class],
+            L26::class => [K26::class, J26::class, I26::class, H26::class, G26::class],
+            K26::class => [J26::class, I26::class, H26::class, G26::class, F26::class],
+            J26::class => [I26::class, H26::class, G26::class, F26::class],
+            I26::class => [H26::class, G26::class, F26::class],
+            H26::class => [G26::class, F26::class],
+            G26::class => [F26::class],
+            F26::class => [E26::class, D26::class, B26::class],
+            E26::class => [D26::class, C26::class],
+            D26::class => [C26::class, B26::class, A26::class],
+            C26::class => [B26::class],
+            B26::class => [A26::class],
+            A26::class => [],
+        ];
+        foreach ($definitions as $class => $deps) {
+            $def = $c->add($class)->setShared(false);
+            foreach ($deps as $dep) {
+                $def->addArgument($dep);
+            }
+        }
+        $this->container = $c;
+    }
+    public function get(string $class): object {
+        return $this->container->get($class);
+    }
+}

--- a/containers/league.predefined/Dockerfile
+++ b/containers/league.predefined/Dockerfile
@@ -1,0 +1,12 @@
+FROM php:8.4-cli
+
+WORKDIR /app
+RUN mkdir /out
+COPY containers/league.predefined/* ./
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git unzip \
+    && rm -rf /var/lib/apt/lists/* \
+    && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
+    && composer install --no-interaction --no-progress
+COPY src/*.php ./
+CMD ["php", "benchmark.php"]

--- a/containers/league.predefined/composer.json
+++ b/containers/league.predefined/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "league/container": "^5.1"
+    }
+}


### PR DESCRIPTION
## Summary
- add a Laravel container variant with cached service bindings
- introduce a League Container variant with predefined, non-shared services

## Testing
- `php -l containers/laravel.cached/AdapterImplementation.php`
- `php -l containers/league.predefined/AdapterImplementation.php`
- `php tools/merge_json.php`
- `php tools/generate_run_summary.php`
- `php tools/generate_graphs.php` *(fails: No benchmark data found)*
- `php tools/generate_readme.php` *(deprecation warnings, completes)*

------
https://chatgpt.com/codex/tasks/task_e_68bdb97fbe40832fb875eb2bba93ee3f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced two dependency injection adapters (Laravel-based and League Container) with prewired graphs for benchmarking.
  - Added ready-to-run Docker images (PHP 8.4) to execute benchmarks with a single command.
- Chores
  - Added Composer configurations to install required container libraries.
  - Streamlined container builds with non-interactive, fail-fast package installation and Composer setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->