### PR TITLE
Include all containers in workflow

### DIFF
--- a/.github/workflows/update-test-results.yml
+++ b/.github/workflows/update-test-results.yml
@@ -37,7 +37,7 @@ jobs:
                     - laravel.cached
                     - league.predefined
                     - dice.configured
-                    - phalcon
+                    #- phalcon
         steps:
             - uses: actions/checkout@v5
             - name: Build container
@@ -114,7 +114,7 @@ jobs:
                     - laravel.cached
                     - league.predefined
                     - dice.configured
-                    - phalcon
+                    #- phalcon
                 test:
                     - f06
                     - f06_startup
@@ -158,7 +158,7 @@ jobs:
                     - laravel.cached
                     - league.predefined
                     - dice.configured
-                    - phalcon
+                    #- phalcon
                 test:
                     - p16
                     - p16_startup
@@ -202,7 +202,7 @@ jobs:
                     - laravel.cached
                     - league.predefined
                     - dice.configured
-                    - phalcon
+                    #- phalcon
                 test:
                     - z26
                     - z26_startup

--- a/.github/workflows/update-test-results.yml
+++ b/.github/workflows/update-test-results.yml
@@ -34,7 +34,10 @@ jobs:
                     - symfony.compiled
                     - laminas-servicemanager
                     - laravel.singletons
-                    #- phalcon
+                    - laravel.cached
+                    - league.predefined
+                    - dice.configured
+                    - phalcon
         steps:
             - uses: actions/checkout@v5
             - name: Build container
@@ -55,7 +58,7 @@ jobs:
             matrix:
                 container:
                     - pimple
-                    - dice
+                    - dice.unconfigured
                     - league-container
         steps:
             - uses: actions/checkout@v5
@@ -108,7 +111,10 @@ jobs:
                     - symfony.compiled
                     - laminas-servicemanager
                     - laravel.singletons
-                    #- phalcon
+                    - laravel.cached
+                    - league.predefined
+                    - dice.configured
+                    - phalcon
                 test:
                     - f06
                     - f06_startup
@@ -149,7 +155,10 @@ jobs:
                     - symfony.compiled
                     - laminas-servicemanager
                     - laravel.singletons
-                    #- phalcon
+                    - laravel.cached
+                    - league.predefined
+                    - dice.configured
+                    - phalcon
                 test:
                     - p16
                     - p16_startup
@@ -190,7 +199,10 @@ jobs:
                     - symfony.compiled
                     - laminas-servicemanager
                     - laravel.singletons
-                    #- phalcon
+                    - laravel.cached
+                    - league.predefined
+                    - dice.configured
+                    - phalcon
                 test:
                     - z26
                     - z26_startup
@@ -226,7 +238,7 @@ jobs:
             matrix:
                 container:
                     - pimple
-                    - dice
+                    - dice.unconfigured
                     - league-container
                 test:
                     - f06
@@ -264,7 +276,7 @@ jobs:
             matrix:
                 container:
                     - pimple
-                    - dice
+                    - dice.unconfigured
                     - league-container
                 test:
                     - p16


### PR DESCRIPTION
## Summary
- list all dependency injection containers in workflow matrices
- reference the correct `dice.unconfigured` container

## Testing
- `yamllint -d '{extends: default, rules: {line-length: disable}}' .github/workflows/update-test-results.yml`


------
https://chatgpt.com/codex/tasks/task_e_68bdbcceeea0832fa0f1fad4b2b24e1e