### PR TITLE
Shift select containers to medium workflow tier

### DIFF
--- a/.github/workflows/update-test-results.yml
+++ b/.github/workflows/update-test-results.yml
@@ -34,9 +34,6 @@ jobs:
                     - symfony.compiled
                     - laminas-servicemanager
                     - laravel.singletons
-                    - laravel.cached
-                    - league.predefined
-                    - dice.configured
                     - phalcon.shared
         steps:
             - uses: actions/checkout@v5
@@ -61,6 +58,9 @@ jobs:
                     - dice.unconfigured
                     - league-container
                     - phalcon.transient
+                    - laravel.cached
+                    - league.predefined
+                    - dice.configured
         steps:
             - uses: actions/checkout@v5
             - name: Build container
@@ -112,9 +112,6 @@ jobs:
                     - symfony.compiled
                     - laminas-servicemanager
                     - laravel.singletons
-                    - laravel.cached
-                    - league.predefined
-                    - dice.configured
                     - phalcon.shared
                 test:
                     - f06
@@ -156,9 +153,6 @@ jobs:
                     - symfony.compiled
                     - laminas-servicemanager
                     - laravel.singletons
-                    - laravel.cached
-                    - league.predefined
-                    - dice.configured
                     - phalcon.shared
                 test:
                     - p16
@@ -200,9 +194,6 @@ jobs:
                     - symfony.compiled
                     - laminas-servicemanager
                     - laravel.singletons
-                    - laravel.cached
-                    - league.predefined
-                    - dice.configured
                     - phalcon.shared
                 test:
                     - z26
@@ -242,6 +233,9 @@ jobs:
                     - dice.unconfigured
                     - league-container
                     - phalcon.transient
+                    - laravel.cached
+                    - league.predefined
+                    - dice.configured
                 test:
                     - f06
                     - f06_startup
@@ -281,6 +275,9 @@ jobs:
                     - dice.unconfigured
                     - league-container
                     - phalcon.transient
+                    - laravel.cached
+                    - league.predefined
+                    - dice.configured
                 test:
                     - p16
                     - p16_startup


### PR DESCRIPTION
## Summary
- move laravel.cached, league.predefined, and dice.configured from fast to medium groups in workflow
- update benchmark matrices to include these containers in medium runs

## Testing
- _No tests were run (workflow-only change)_

------
https://chatgpt.com/codex/tasks/task_e_68bdd67167bc832f857c309c38a3eee2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Rebalanced CI workflows by shifting certain container targets from fast to medium build and benchmark runs to optimize execution time and resource usage.
  - Ensures consistent participation of these targets across appropriate pipelines without altering outputs.

- Tests
  - Updated test and benchmark matrices only; no changes to test logic or result generation.
  - Maintains overall coverage while distributing workloads more evenly across pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->