### PR TITLE
docs: add container run instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,17 @@ The "quickly" container is maintained by the same author as this benchmark, and 
 | --- | --- |
 | PHP | 8.4 |
 
+## Running individual benchmarks
+
+Build the container and execute a benchmark using focker (replace with docker if needed):
+
+```sh
+focker build -t di-benchmark-php-di -f containers/php-di/Dockerfile .
+focker run --rm -v "$PWD:/out" di-benchmark-php-di php benchmark.php f06 1
+```
+
+The build step prepares the image for the chosen container, and the run command executes a single run of the specified test (for example, `f06`). The resulting `results.json` file will be written to the current directory.
+
 ## f06
 
 Small dependency graph including 6 classes total (excluding container startup time)

--- a/tools/generate_readme.php
+++ b/tools/generate_readme.php
@@ -89,6 +89,17 @@ if (!empty($data['php_version'])) {
     $lines[] = '| PHP | ' . $data['php_version'] . ' |';
     $lines[] = '';
 }
+$lines[] = '## Running individual benchmarks';
+$lines[] = '';
+$lines[] = 'Build the container and execute a benchmark using focker (replace with docker if needed):';
+$lines[] = '';
+$lines[] = '```sh';
+$lines[] = 'focker build -t di-benchmark-php-di -f containers/php-di/Dockerfile .';
+$lines[] = 'focker run --rm -v "$PWD:/out" di-benchmark-php-di php benchmark.php f06 1';
+$lines[] = '```';
+$lines[] = '';
+$lines[] = 'The build step prepares the image for the chosen container, and the run command executes a single run of the specified test (for example, `f06`). The resulting `results.json` file will be written to the current directory.';
+$lines[] = '';
 $results = $data['results'] ?? [];
 $tests = [
     'f06' => [


### PR DESCRIPTION
## Summary
- document how to build and run individual benchmark containers
- embed the same instructions into the readme generator

## Testing
- `php -l tools/generate_readme.php`
- `php tools/generate_readme.php` *(deprecated float to int warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68bde0116484832f84451fd22945f183

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a “Running individual benchmarks” section explaining how to build the container and execute a single benchmark, with step-by-step commands and an example (e.g., running one test).
  * Clarifies that the run writes results.json to the current directory.
  * Ensures the autogenerated README consistently includes this section after the Environment details, improving guidance for users running targeted local benchmarks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->