### PR TITLE
fix: avoid implicit float to int in readme generator

### DIFF
--- a/tools/generate_readme.php
+++ b/tools/generate_readme.php
@@ -48,10 +48,10 @@ function format_time(float $seconds): string {
     if ($seconds === 0.0) {
         return '-';
     }
-    $s = floor($seconds);
-    $ms = floor(($seconds * 1000) % 1000);
-    $us = floor(($seconds * 1000000) % 1000);
-    $ns = floor(($seconds * 1000000000) % 1000);
+    $s = (int) floor($seconds);
+    $ms = ((int) floor($seconds * 1000)) % 1000;
+    $us = ((int) floor($seconds * 1000000)) % 1000;
+    $ns = ((int) floor($seconds * 1000000000)) % 1000;
     $parts = [];
     if ($s > 0) {
         $parts[] = $s . 's';


### PR DESCRIPTION
## Summary
- cast timing values to int before modulus in README generator to avoid deprecated implicit float-to-int conversion warnings

## Testing
- `php -l tools/generate_readme.php`
- `php tools/generate_readme.php`


------
https://chatgpt.com/codex/tasks/task_e_68bde13d5eac832f92d146dfaff7035b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected sub-second time formatting to eliminate floating-point rounding glitches.
  * Ensures milliseconds, microseconds, and nanoseconds are calculated using integer arithmetic for consistent, predictable output.
  * Improves accuracy of displayed durations without changing any user-facing interfaces or settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->