### PR TITLE
Expand environment details in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Each test is executed with and without container startup time to measure resolut
 | Component | Version |
 | --- | --- |
 | PHP | 8.4 |
+| Docker | 24 (GitHub Actions) |
+| OS | Ubuntu 22.04 (github runner ubuntu-latest) |
 
 ## Running individual benchmarks
 

--- a/run_summary.yaml
+++ b/run_summary.yaml
@@ -1,4 +1,6 @@
 php_version: "8.4"
+docker_version: "24 (GitHub Actions)"
+os: "Ubuntu 22.04 (github runner ubuntu-latest)"
 dependency_versions:
   aura-di:
     aura/di: "^5.0"

--- a/tools/generate_readme.php
+++ b/tools/generate_readme.php
@@ -92,12 +92,24 @@ $lines[] = 'Each file contains all required classes and avoids autoloading so th
 $lines[] = 'Each test is executed with and without container startup time to measure resolution speed and initialization cost.';
 $lines[] = '';
 $depVersions = $data['dependency_versions'] ?? [];
+$envRows = [];
 if (!empty($data['php_version'])) {
+    $envRows[] = '| PHP | ' . $data['php_version'] . ' |';
+}
+if (!empty($data['docker_version'])) {
+    $envRows[] = '| Docker | ' . $data['docker_version'] . ' |';
+}
+if (!empty($data['os'])) {
+    $envRows[] = '| OS | ' . $data['os'] . ' |';
+}
+if (!empty($envRows)) {
     $lines[] = '## Environment';
     $lines[] = '';
     $lines[] = '| Component | Version |';
     $lines[] = '| --- | --- |';
-    $lines[] = '| PHP | ' . $data['php_version'] . ' |';
+    foreach ($envRows as $row) {
+        $lines[] = $row;
+    }
     $lines[] = '';
 }
 $lines[] = '## Running individual benchmarks';


### PR DESCRIPTION
## Summary
- record Docker and GitHub runner OS in run summary
- display Docker and OS environment info in generated README

## Testing
- `php -l tools/generate_readme.php`


------
https://chatgpt.com/codex/tasks/task_e_68bde5306f64832f937d892282151b1b