### PR TITLE
fix: correct docker references

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ Each test is executed with and without container startup time to measure resolut
 
 ## Running individual benchmarks
 
-Build the container and execute a benchmark using focker (replace with docker if needed):
+Build the container and execute a benchmark using docker:
 
 ```sh
-focker build -t di-benchmark-php-di -f containers/php-di/Dockerfile .
-focker run --rm -v "$PWD:/out" di-benchmark-php-di php benchmark.php f06 1
+docker build -t di-benchmark-php-di -f containers/php-di/Dockerfile .
+docker run --rm -v "$PWD:/out" di-benchmark-php-di php benchmark.php f06 1
 ```
 
 The build step prepares the image for the chosen container, and the run command executes a single run of the specified test (for example, `f06`). The resulting `results.json` file will be written to the current directory.

--- a/tools/generate_readme.php
+++ b/tools/generate_readme.php
@@ -102,11 +102,11 @@ if (!empty($data['php_version'])) {
 }
 $lines[] = '## Running individual benchmarks';
 $lines[] = '';
-$lines[] = 'Build the container and execute a benchmark using focker (replace with docker if needed):';
+$lines[] = 'Build the container and execute a benchmark using docker:';
 $lines[] = '';
 $lines[] = '```sh';
-$lines[] = 'focker build -t di-benchmark-php-di -f containers/php-di/Dockerfile .';
-$lines[] = 'focker run --rm -v "$PWD:/out" di-benchmark-php-di php benchmark.php f06 1';
+$lines[] = 'docker build -t di-benchmark-php-di -f containers/php-di/Dockerfile .';
+$lines[] = 'docker run --rm -v "$PWD:/out" di-benchmark-php-di php benchmark.php f06 1';
 $lines[] = '```';
 $lines[] = '';
 $lines[] = 'The build step prepares the image for the chosen container, and the run command executes a single run of the specified test (for example, `f06`). The resulting `results.json` file will be written to the current directory.';


### PR DESCRIPTION
## Summary
- fix focker typo in documentation and scripts

## Testing
- `php -l tools/generate_readme.php`
- `php tools/generate_readme.php`


------
https://chatgpt.com/codex/tasks/task_e_68bde5aabe44832fa475ec3c7e0ffe8f