### PR TITLE
docs: require README edits mirrored in generation script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@ This repository contains PHP benchmark code. These instructions help maintain co
 - Generate `run_summary.yaml` with `php tools/generate_run_summary.php`.
 - Create JPG graphs from the consolidated results via `php tools/generate_graphs.php`.
 - Regenerate the `README.md` using `php tools/generate_readme.php`.
+- Ensure any changes to `README.md` are also applied in `tools/generate_readme.php`.
 
 ## Tool Scripts
 - `tools/merge_json.php`: combines individual run JSON files and computes summary statistics.


### PR DESCRIPTION
## Summary
- document that README changes must also be applied to `tools/generate_readme.php`

## Testing
- no tests required

------
https://chatgpt.com/codex/tasks/task_e_68bde7802bfc832fbaa885cacfa38313