### PR TITLE
Invite contributions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,3 +182,5 @@ Large dependency graph including a total of 26 classes. Skipped for all but the 
 | symfony(compiled) | ^7.0 | 7ms, 238µs, 817ns | 5ms, 857µs, 944ns | 18ms, 877µs, 29ns |
 
 ![z26 startup](images/speed_comparison_with_startup26.jpg)
+
+Questions, issues, and new containers are welcome!

--- a/tools/generate_readme.php
+++ b/tools/generate_readme.php
@@ -200,4 +200,6 @@ foreach ($tests as $testKey => $info) {
     $lines[] = '![' . $info['title'] . '](' . $info['image'] . ')';
     $lines[] = '';
 }
+$lines[] = 'Questions, issues, and new containers are welcome!';
+$lines[] = '';
 file_put_contents('README.md', implode("\n", $lines));


### PR DESCRIPTION
## Summary
- encourage community input with a short invitation for issues, questions, and new containers
- update README generator to emit the same invitation

## Testing
- `php -l tools/generate_readme.php`


------
https://chatgpt.com/codex/tasks/task_e_68bde93b31a8832fb9b4a9dd75b88979