### PR TITLE
Rebalance workflow container groups based on f06 performance

### DIFF
--- a/.github/workflows/update-test-results.yml
+++ b/.github/workflows/update-test-results.yml
@@ -26,6 +26,7 @@ jobs:
         strategy:
             matrix:
                 container:
+                    - aura-di
                     - nette-di
                     - php-di
                     - quickly.compiled
@@ -56,10 +57,6 @@ jobs:
                 container:
                     - pimple
                     - dice.unconfigured
-                    - league-container
-                    - phalcon.transient
-                    - laravel.cached
-                    - league.predefined
                     - dice.configured
         steps:
             - uses: actions/checkout@v5
@@ -81,8 +78,11 @@ jobs:
             matrix:
                 container:
                     - laravel.unconfigured
-                    - aura-di
                     - auryn
+                    - phalcon.transient
+                    - laravel.cached
+                    - league-container
+                    - league.predefined
         steps:
             - uses: actions/checkout@v5
             - name: Build container
@@ -104,6 +104,7 @@ jobs:
         strategy:
             matrix:
                 container:
+                    - aura-di
                     - nette-di
                     - php-di
                     - quickly.compiled
@@ -145,6 +146,7 @@ jobs:
         strategy:
             matrix:
                 container:
+                    - aura-di
                     - nette-di
                     - php-di
                     - quickly.compiled
@@ -186,6 +188,7 @@ jobs:
         strategy:
             matrix:
                 container:
+                    - aura-di
                     - nette-di
                     - php-di
                     - quickly.compiled
@@ -231,10 +234,6 @@ jobs:
                 container:
                     - pimple
                     - dice.unconfigured
-                    - league-container
-                    - phalcon.transient
-                    - laravel.cached
-                    - league.predefined
                     - dice.configured
                 test:
                     - f06
@@ -273,10 +272,6 @@ jobs:
                 container:
                     - pimple
                     - dice.unconfigured
-                    - league-container
-                    - phalcon.transient
-                    - laravel.cached
-                    - league.predefined
                     - dice.configured
                 test:
                     - p16
@@ -321,8 +316,11 @@ jobs:
             matrix:
                 container:
                     - laravel.unconfigured
-                    - aura-di
                     - auryn
+                    - phalcon.transient
+                    - laravel.cached
+                    - league-container
+                    - league.predefined
                 test:
                     - f06
                     - f06_startup


### PR DESCRIPTION
## Summary
- Move aura-di to fast benchmarks
- Shift phalcon.transient, laravel.cached, league-container, and league.predefined to slow benchmarks
- Trim medium benchmarks to pimple and dice variations only

## Testing
- `python - <<'PY'
import yaml, sys
yaml.safe_load(open('.github/workflows/update-test-results.yml'))
print('YAML OK')
PY`

------
https://chatgpt.com/codex/tasks/task_e_68be4d82a61c832fb86f54431598c5da

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test and benchmark coverage with updated matrices to include additional containers and rebalance suites.
  * Streamlined fast/medium/slow benchmarks for more representative and efficient validation.
  * Improved CI reliability without altering product behavior.

* **Chores**
  * Updated CI configurations to optimize build and benchmark execution times and maintainability, with no impact on user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->