### PR TITLE
Organize latest benchmark results

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # PHP Dependency Injection Benchmark
 
-Run from 2025-09-07
-
 Dependency injection (DI) containers manage the creation and wiring of object dependencies, allowing applications to remain decoupled and easier to maintain.
 Testing these containers verifies that they resolve dependencies correctly and perform efficiently, which is vital for application reliability.
 
@@ -46,7 +44,11 @@ docker run --rm -v "$PWD:/out" di-benchmark-php-di php benchmark.php f06 1
 
 The build step prepares the image for the chosen container, and the run command executes a single run of the specified test (for example, `f06`). The resulting `results.json` file will be written to the current directory.
 
-## 📊 f06
+## Latest Results
+
+Run from 2025-09-07
+
+### 📊 f06
 
 Small dependency graph including 6 classes total (excluding container startup time)
 
@@ -74,7 +76,7 @@ Small dependency graph including 6 classes total (excluding container startup ti
 
 ![📊 f06](images/speed_comparison_without_startup06.jpg)
 
-## 🚀 f06 startup
+### 🚀 f06 startup
 
 Small dependency graph including 6 classes total (includes container startup time)
 
@@ -102,7 +104,7 @@ Small dependency graph including 6 classes total (includes container startup tim
 
 ![🚀 f06 startup](images/speed_comparison_with_startup06.jpg)
 
-## 📊 p16
+### 📊 p16
 
 Medium size dependency graph including 16 classes total. Skipped for the slowest DI-Containers for runtime reasons. (excluding container startup time)
 
@@ -127,7 +129,7 @@ Medium size dependency graph including 16 classes total. Skipped for the slowest
 
 ![📊 p16](images/speed_comparison_without_startup16.jpg)
 
-## 🚀 p16 startup
+### 🚀 p16 startup
 
 Medium size dependency graph including 16 classes total. Skipped for the slowest DI-Containers for runtime reasons. (includes container startup time)
 
@@ -152,7 +154,7 @@ Medium size dependency graph including 16 classes total. Skipped for the slowest
 
 ![🚀 p16 startup](images/speed_comparison_with_startup16.jpg)
 
-## 📊 z26
+### 📊 z26
 
 Large dependency graph including a total of 26 classes. Skipped for all but the fastest DI-Containers for runtime reasons. (excluding container startup time)
 
@@ -170,7 +172,7 @@ Large dependency graph including a total of 26 classes. Skipped for all but the 
 
 ![📊 z26](images/speed_comparison_without_startup26.jpg)
 
-## 🚀 z26 startup
+### 🚀 z26 startup
 
 Large dependency graph including a total of 26 classes. Skipped for all but the fastest DI-Containers for runtime reasons. (includes container startup time)
 

--- a/tools/generate_readme.php
+++ b/tools/generate_readme.php
@@ -76,8 +76,6 @@ $data = parse_simple_yaml('run_summary.yaml');
 $lines = [];
 $lines[] = '# PHP Dependency Injection Benchmark';
 $lines[] = '';
-$lines[] = 'Run from ' . date('Y-m-d');
-$lines[] = '';
 $lines[] = 'Dependency injection (DI) containers manage the creation and wiring of object dependencies, allowing applications to remain decoupled and easier to maintain.';
 $lines[] = 'Testing these containers verifies that they resolve dependencies correctly and perform efficiently, which is vital for application reliability.';
 $lines[] = '';
@@ -127,6 +125,10 @@ $lines[] = '```';
 $lines[] = '';
 $lines[] = 'The build step prepares the image for the chosen container, and the run command executes a single run of the specified test (for example, `f06`). The resulting `results.json` file will be written to the current directory.';
 $lines[] = '';
+$lines[] = '## Latest Results';
+$lines[] = '';
+$lines[] = 'Run from ' . date('Y-m-d');
+$lines[] = '';
 $results = $data['results'] ?? [];
 $tests = [
     'f06' => [
@@ -161,7 +163,7 @@ $tests = [
     ],
 ];
 foreach ($tests as $testKey => $info) {
-    $lines[] = '## ' . $info['title'];
+    $lines[] = '### ' . $info['title'];
     if (!empty($info['description'])) {
         $lines[] = '';
         $lines[] = $info['description'];


### PR DESCRIPTION
## Summary
- Group all benchmark tables under a new **Latest Results** section
- Move run date info into the Latest Results section
- Adjust README generator to output the new structure

## Testing
- `php -l tools/generate_readme.php`


------
https://chatgpt.com/codex/tasks/task_e_68be4e2e8fc0832fb69e3ab9d9a29252

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a top-level “Latest Results” section that consolidates all result sections, with the run date shown inside it.
  * Downgraded result-related headings from level 2 to level 3 for improved hierarchy (content unchanged).
* **Chores**
  * Updated README generation to use the new structure and heading levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->