### PR TITLE
Automate workflow categories from latest benchmarks

### DIFF
--- a/.github/workflows/update-test-results.yml
+++ b/.github/workflows/update-test-results.yml
@@ -26,15 +26,16 @@ jobs:
         strategy:
             matrix:
                 container:
+                    - aura-di
+                    - laminas-servicemanager
+                    - laravel.singletons
                     - nette-di
+                    - phalcon.shared
                     - php-di
                     - quickly.compiled
                     - quickly.configured
                     - quickly.reflection
                     - symfony.compiled
-                    - laminas-servicemanager
-                    - laravel.singletons
-                    - phalcon.shared
         steps:
             - uses: actions/checkout@v5
             - name: Build container
@@ -54,13 +55,9 @@ jobs:
         strategy:
             matrix:
                 container:
-                    - pimple
-                    - dice.unconfigured
-                    - league-container
-                    - phalcon.transient
-                    - laravel.cached
-                    - league.predefined
                     - dice.configured
+                    - dice.unconfigured
+                    - pimple
         steps:
             - uses: actions/checkout@v5
             - name: Build container
@@ -80,9 +77,12 @@ jobs:
         strategy:
             matrix:
                 container:
-                    - laravel.unconfigured
-                    - aura-di
                     - auryn
+                    - laravel.cached
+                    - laravel.unconfigured
+                    - league-container
+                    - league.predefined
+                    - phalcon.transient
         steps:
             - uses: actions/checkout@v5
             - name: Build container
@@ -104,15 +104,16 @@ jobs:
         strategy:
             matrix:
                 container:
+                    - aura-di
+                    - laminas-servicemanager
+                    - laravel.singletons
                     - nette-di
+                    - phalcon.shared
                     - php-di
                     - quickly.compiled
                     - quickly.configured
                     - quickly.reflection
                     - symfony.compiled
-                    - laminas-servicemanager
-                    - laravel.singletons
-                    - phalcon.shared
                 test:
                     - f06
                     - f06_startup
@@ -145,15 +146,16 @@ jobs:
         strategy:
             matrix:
                 container:
+                    - aura-di
+                    - laminas-servicemanager
+                    - laravel.singletons
                     - nette-di
+                    - phalcon.shared
                     - php-di
                     - quickly.compiled
                     - quickly.configured
                     - quickly.reflection
                     - symfony.compiled
-                    - laminas-servicemanager
-                    - laravel.singletons
-                    - phalcon.shared
                 test:
                     - p16
                     - p16_startup
@@ -186,15 +188,16 @@ jobs:
         strategy:
             matrix:
                 container:
+                    - aura-di
+                    - laminas-servicemanager
+                    - laravel.singletons
                     - nette-di
+                    - phalcon.shared
                     - php-di
                     - quickly.compiled
                     - quickly.configured
                     - quickly.reflection
                     - symfony.compiled
-                    - laminas-servicemanager
-                    - laravel.singletons
-                    - phalcon.shared
                 test:
                     - z26
                     - z26_startup
@@ -229,13 +232,9 @@ jobs:
         strategy:
             matrix:
                 container:
-                    - pimple
-                    - dice.unconfigured
-                    - league-container
-                    - phalcon.transient
-                    - laravel.cached
-                    - league.predefined
                     - dice.configured
+                    - dice.unconfigured
+                    - pimple
                 test:
                     - f06
                     - f06_startup
@@ -271,13 +270,9 @@ jobs:
         strategy:
             matrix:
                 container:
-                    - pimple
-                    - dice.unconfigured
-                    - league-container
-                    - phalcon.transient
-                    - laravel.cached
-                    - league.predefined
                     - dice.configured
+                    - dice.unconfigured
+                    - pimple
                 test:
                     - p16
                     - p16_startup
@@ -320,9 +315,12 @@ jobs:
         strategy:
             matrix:
                 container:
-                    - laravel.unconfigured
-                    - aura-di
                     - auryn
+                    - laravel.cached
+                    - laravel.unconfigured
+                    - league-container
+                    - league.predefined
+                    - phalcon.transient
                 test:
                     - f06
                     - f06_startup
@@ -379,12 +377,14 @@ jobs:
               run: php tools/generate_run_summary.php
             - name: Generate README
               run: php tools/generate_readme.php
+            - name: Update workflow
+              run: php tools/update_workflow.php
             - name: Commit results
               run: |
                   git config --global user.name 'github-actions[bot]'
                   git config --global user.email \
                       'github-actions[bot]@users.noreply.github.com'
-                  git add README.md images/speed_comparison_*.jpg run_summary.yaml
+                  git add README.md images/speed_comparison_*.jpg run_summary.yaml .github/workflows/update-test-results.yml
                   if [ "$GITHUB_EVENT_NAME" = "schedule" ]; then
                       git add archive
                   fi

--- a/tools/update_workflow.php
+++ b/tools/update_workflow.php
@@ -1,0 +1,76 @@
+<?php
+
+chdir(__DIR__ . '/..');
+
+function parse_run_summary(string $filename): array {
+    $lines = file($filename);
+    $containers = [];
+    $values = [];
+    $inResults = false;
+    $currentContainer = null;
+    $currentMetric = null;
+    foreach ($lines as $line) {
+        if (!$inResults) {
+            if (preg_match('/^results:/', $line)) {
+                $inResults = true;
+            }
+            continue;
+        }
+        if (preg_match('/^\s{2}([a-z0-9\.\-]+):\s*$/i', $line, $m)) {
+            $currentContainer = $m[1];
+            $containers[] = $currentContainer;
+            continue;
+        }
+        if (preg_match('/^\s{4}([a-z0-9_]+):\s*$/i', $line, $m)) {
+            $currentMetric = $m[1];
+            continue;
+        }
+        if (preg_match('/^\s{6}average:\s*([0-9\.]+)/i', $line, $m)) {
+            $values[$currentContainer][$currentMetric] = (float) $m[1];
+        }
+    }
+    return [$containers, $values];
+}
+
+function replace_container_list(string $workflow, string $job, array $containers): string {
+    $pattern = '/(^    ' . preg_quote($job, '/') . ":\n[\s\S]*?container:\n)(?: {20}- .*?\n)+/m";
+    $replacement = "$1" . implode('', array_map(fn($c) => "                    - $c\n", $containers));
+    return preg_replace($pattern, $replacement, $workflow);
+}
+
+[$containers, $summary] = parse_run_summary('run_summary.yaml');
+
+$fast = [];
+$medium = [];
+$slow = [];
+
+foreach ($containers as $container) {
+    $time = $summary[$container]['f06'] ?? null;
+    if ($time === null) {
+        continue;
+    }
+    if ($time < 0.01) {
+        $fast[] = $container;
+    } elseif ($time <= 0.1) {
+        $medium[] = $container;
+    } else {
+        $slow[] = $container;
+    }
+}
+
+$workflowFile = '.github/workflows/update-test-results.yml';
+$workflow = file_get_contents($workflowFile);
+
+$workflow = replace_container_list($workflow, 'build-fast', $fast);
+$workflow = replace_container_list($workflow, 'benchmark-fast-06', $fast);
+$workflow = replace_container_list($workflow, 'benchmark-fast-16', $fast);
+$workflow = replace_container_list($workflow, 'benchmark-fast-26', $fast);
+
+$workflow = replace_container_list($workflow, 'build-medium', $medium);
+$workflow = replace_container_list($workflow, 'benchmark-medium-06', $medium);
+$workflow = replace_container_list($workflow, 'benchmark-medium-16', $medium);
+
+$workflow = replace_container_list($workflow, 'build-slow', $slow);
+$workflow = replace_container_list($workflow, 'benchmark-slow-06', $slow);
+
+file_put_contents($workflowFile, $workflow);


### PR DESCRIPTION
## Summary
- add script to reclassify containers as fast/medium/slow from last `f06` timings and update workflow matrices
- invoke workflow updater during aggregation and commit workflow file automatically

## Testing
- `php -l tools/update_workflow.php`


------
https://chatgpt.com/codex/tasks/task_e_68be4eb3e9e8832fa6b01fbe07d6aac0