### PR TITLE
feat: add environment badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # PHP Dependency Injection Benchmark
 
+![PHP Version](https://img.shields.io/badge/PHP-8.4-blue?logo=php) ![Docker Version](https://img.shields.io/badge/Docker-%2A-lightgrey?logo=docker) ![OS](https://img.shields.io/badge/OS-ubuntu%20latest-blue?logo=ubuntu)
+
 Dependency injection (DI) containers manage the creation and wiring of object dependencies, allowing applications to remain decoupled and easier to maintain.
 Testing these containers verifies that they resolve dependencies correctly and perform efficiently, which is vital for application reliability.
 
@@ -24,14 +26,6 @@ The class names (`f06`, `p16`, `z26`) follow a group-unique letter plus total cl
 
 Each file contains all required classes and avoids autoloading so that container performance measurements exclude file-loading overhead.
 Each test is executed with and without container startup time to measure resolution speed and initialization cost.
-
-## 🌍 Environment
-
-| Component | Version |
-| --- | --- |
-| PHP | 8.4 |
-| Docker | * |
-| OS | ubuntu latest |
 
 ## 🚀 Running individual benchmarks
 

--- a/tools/generate_readme.php
+++ b/tools/generate_readme.php
@@ -73,8 +73,14 @@ function format_time(float $seconds): string {
 
 $data = parse_simple_yaml('run_summary.yaml');
 
+$phpBadge = '![PHP Version](https://img.shields.io/badge/PHP-' . rawurlencode($data['php_version']) . '-blue?logo=php)';
+$dockerBadge = '![Docker Version](https://img.shields.io/badge/Docker-' . rawurlencode($data['docker_version'] ?? '*') . '-lightgrey?logo=docker)';
+$osBadge = '![OS](https://img.shields.io/badge/OS-' . rawurlencode($data['os'] ?? 'ubuntu latest') . '-blue?logo=ubuntu)';
+
 $lines = [];
 $lines[] = '# PHP Dependency Injection Benchmark';
+$lines[] = '';
+$lines[] = $phpBadge . ' ' . $dockerBadge . ' ' . $osBadge;
 $lines[] = '';
 $lines[] = 'Dependency injection (DI) containers manage the creation and wiring of object dependencies, allowing applications to remain decoupled and easier to maintain.';
 $lines[] = 'Testing these containers verifies that they resolve dependencies correctly and perform efficiently, which is vital for application reliability.';
@@ -102,18 +108,6 @@ $lines[] = 'Each file contains all required classes and avoids autoloading so th
 $lines[] = 'Each test is executed with and without container startup time to measure resolution speed and initialization cost.';
 $lines[] = '';
 $depVersions = $data['dependency_versions'] ?? [];
-$envRows = [];
-$envRows[] = '| PHP | ' . $data['php_version'] . ' |';
-$envRows[] = '| Docker | ' . ($data['docker_version'] ?? '*') . ' |';
-$envRows[] = '| OS | ' . ($data['os'] ?? 'ubuntu latest') . ' |';
-$lines[] = '## 🌍 Environment';
-$lines[] = '';
-$lines[] = '| Component | Version |';
-$lines[] = '| --- | --- |';
-foreach ($envRows as $row) {
-    $lines[] = $row;
-}
-$lines[] = '';
 $lines[] = '## 🚀 Running individual benchmarks';
 $lines[] = '';
 $lines[] = 'Build the container and execute a benchmark using docker:';


### PR DESCRIPTION
## Summary
- replace environment table with shields badges under README title
- update README generator to emit badges instead of environment section

## Testing
- `php -l tools/generate_readme.php`


------
https://chatgpt.com/codex/tasks/task_e_68befe17aa40832f866614bdd931d2e0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Added badges under the title (PHP, Docker, OS) and adjusted hero image placement.
  - Expanded introduction to cover reliability, performance, and bias mitigation via multiple runs.
  - Linked run_summary.yaml and documented monthly archived outputs.
  - Reworked Test Files section to clearly describe three dependency graphs (6, 16, 26 classes) and naming rationale.
  - Removed the Environment section; version info now conveyed via badges.
  - Preserved benchmark execution guidance and clarified data access details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->