### PR TITLE
Show skipped status in benchmark graphs

### DIFF
--- a/tools/generate_graphs.php
+++ b/tools/generate_graphs.php
@@ -125,6 +125,7 @@ function create_bar_chart(array $values, string $title, string $filename, array 
         if ($logVal === null || $maxTick <= 0) {
             continue;
         }
+        $originalVal = $logVal;
         if ($logVal < 0) {
             $logVal = -1 * $logVal;
         }
@@ -134,8 +135,12 @@ function create_bar_chart(array $values, string $title, string $filename, array 
         $x1 = $leftMargin;
         $x2 = (int) ($x1 + $barWidthVal);
         imagefilledrectangle($img, $x1, $y1, $x2, $y2, $blue);
-        $percentage = ($logVal / $maxLog) * 100;
-        $percentageText = sprintf('%.1f%%', $percentage);
+        if ($originalVal <= 0) {
+            $percentageText = 'skipped due to performance';
+        } else {
+            $percentage = ($logVal / $maxLog) * 100;
+            $percentageText = sprintf('%.1f%%', $percentage);
+        }
         $percentageY = (int) ($y1 + ($barHeight - imagefontheight(2)) / 2);
         $percentageX = $x2 + 5;
         imagestring($img, 2, $percentageX, $percentageY, $percentageText, $black);


### PR DESCRIPTION
## Summary
- Display `skipped due to performance` in graphs instead of `0%` for containers that are skipped

## Testing
- `php -l tools/generate_graphs.php`
- `php tools/generate_graphs.php`


------
https://chatgpt.com/codex/tasks/task_e_68bf014fd12c832f8b2a9c021b1937d4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Corrected percentage labels in bar charts: non-positive values now display “skipped due to performance” instead of an invalid percentage.
  - Preserved original values to ensure accurate labeling after internal checks.
  - Maintained consistent bar widths by treating negative values as absolute magnitudes.
  - Improved readability of graphs with clearer status messaging for skipped entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->