### PR TITLE
Add Zen container

### DIFF
--- a/containers/zen.filebased/AdapterImplementation.php
+++ b/containers/zen.filebased/AdapterImplementation.php
@@ -1,0 +1,54 @@
+<?php
+
+use WoohooLabs\Zen\RuntimeContainer;
+use WoohooLabs\Zen\Config\AbstractCompilerConfig;
+use WoohooLabs\Zen\Config\AbstractContainerConfig;
+use WoohooLabs\Zen\Config\EntryPoint\ClassEntryPoint;
+use WoohooLabs\Zen\Config\FileBasedDefinition\FileBasedDefinitionConfig;
+use WoohooLabs\Zen\Config\FileBasedDefinition\FileBasedDefinitionConfigInterface;
+use WoohooLabs\Zen\Config\Preload\PreloadConfig;
+use WoohooLabs\Zen\Config\Preload\PreloadConfigInterface;
+
+class AdapterImplementation {
+    private RuntimeContainer $container;
+    public function __construct() {
+        $this->container = new RuntimeContainer(new CompilerConfig());
+    }
+    public function get(string $class): object {
+        return $this->container->get($class);
+    }
+}
+
+class CompilerConfig extends AbstractCompilerConfig {
+    public function getContainerNamespace(): string {
+        return '';
+    }
+    public function getContainerClassName(): string {
+        return 'GeneratedContainer';
+    }
+    public function useConstructorInjection(): bool {
+        return true;
+    }
+    public function usePropertyInjection(): bool {
+        return false;
+    }
+    public function getPreloadConfig(): PreloadConfigInterface {
+        return PreloadConfig::disabled();
+    }
+    public function getFileBasedDefinitionConfig(): FileBasedDefinitionConfigInterface {
+        return FileBasedDefinitionConfig::enabledGlobally('definitions');
+    }
+    public function getContainerConfigs(): array {
+        return [new ContainerConfig()];
+    }
+}
+
+class ContainerConfig extends AbstractContainerConfig {
+    protected function getEntryPoints(): array {
+        return [
+            ClassEntryPoint::create(F06::class),
+            ClassEntryPoint::create(P16::class),
+            ClassEntryPoint::create(Z26::class),
+        ];
+    }
+}

--- a/containers/zen.filebased/Dockerfile
+++ b/containers/zen.filebased/Dockerfile
@@ -1,0 +1,12 @@
+FROM php:8.4-cli
+
+WORKDIR /app
+RUN mkdir /out definitions
+COPY containers/zen.filebased/* ./
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git unzip \
+    && rm -rf /var/lib/apt/lists/* \
+    && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
+    && composer install --no-interaction --no-progress
+COPY src/*.php ./
+CMD ["php", "benchmark.php"]

--- a/containers/zen.filebased/composer.json
+++ b/containers/zen.filebased/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "woohoolabs/zen": "^3.1"
+    }
+}

--- a/containers/zen.unconfigured/AdapterImplementation.php
+++ b/containers/zen.unconfigured/AdapterImplementation.php
@@ -1,0 +1,54 @@
+<?php
+
+use WoohooLabs\Zen\RuntimeContainer;
+use WoohooLabs\Zen\Config\AbstractCompilerConfig;
+use WoohooLabs\Zen\Config\AbstractContainerConfig;
+use WoohooLabs\Zen\Config\EntryPoint\ClassEntryPoint;
+use WoohooLabs\Zen\Config\FileBasedDefinition\FileBasedDefinitionConfig;
+use WoohooLabs\Zen\Config\FileBasedDefinition\FileBasedDefinitionConfigInterface;
+use WoohooLabs\Zen\Config\Preload\PreloadConfig;
+use WoohooLabs\Zen\Config\Preload\PreloadConfigInterface;
+
+class AdapterImplementation {
+    private RuntimeContainer $container;
+    public function __construct() {
+        $this->container = new RuntimeContainer(new CompilerConfig());
+    }
+    public function get(string $class): object {
+        return $this->container->get($class);
+    }
+}
+
+class CompilerConfig extends AbstractCompilerConfig {
+    public function getContainerNamespace(): string {
+        return '';
+    }
+    public function getContainerClassName(): string {
+        return 'GeneratedContainer';
+    }
+    public function useConstructorInjection(): bool {
+        return true;
+    }
+    public function usePropertyInjection(): bool {
+        return false;
+    }
+    public function getPreloadConfig(): PreloadConfigInterface {
+        return PreloadConfig::disabled();
+    }
+    public function getFileBasedDefinitionConfig(): FileBasedDefinitionConfigInterface {
+        return FileBasedDefinitionConfig::disabledGlobally();
+    }
+    public function getContainerConfigs(): array {
+        return [new ContainerConfig()];
+    }
+}
+
+class ContainerConfig extends AbstractContainerConfig {
+    protected function getEntryPoints(): array {
+        return [
+            ClassEntryPoint::create(F06::class),
+            ClassEntryPoint::create(P16::class),
+            ClassEntryPoint::create(Z26::class),
+        ];
+    }
+}

--- a/containers/zen.unconfigured/Dockerfile
+++ b/containers/zen.unconfigured/Dockerfile
@@ -1,0 +1,12 @@
+FROM php:8.4-cli
+
+WORKDIR /app
+RUN mkdir /out
+COPY containers/zen.unconfigured/* ./
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git unzip \
+    && rm -rf /var/lib/apt/lists/* \
+    && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
+    && composer install --no-interaction --no-progress
+COPY src/*.php ./
+CMD ["php", "benchmark.php"]

--- a/containers/zen.unconfigured/composer.json
+++ b/containers/zen.unconfigured/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "woohoolabs/zen": "^3.1"
+    }
+}


### PR DESCRIPTION
## Summary
- rename Zen container to `zen.unconfigured`
- add `zen.filebased` variant using file-based definition config

## Testing
- `php -l containers/zen.unconfigured/AdapterImplementation.php`
- `php -l containers/zen.filebased/AdapterImplementation.php`


------
https://chatgpt.com/codex/tasks/task_e_68befeb4f8a8832f88516cf679d93209

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added two dependency injection container options using Zen: a file-based configuration and an unconfigured mode with constructor injection.
  - Enables resolving services via the new adapters for improved flexibility in setup.

- Chores
  - Added Docker images for both container options to simplify running the app in containers.
  - Declared required dependency on Zen via Composer for both setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->