### PR TITLE
Consider p16 and z26 in workflow placement

### DIFF
--- a/.github/workflows/update-test-results.yml
+++ b/.github/workflows/update-test-results.yml
@@ -55,9 +55,7 @@ jobs:
         strategy:
             matrix:
                 container:
-                    - dice.configured
-                    - dice.unconfigured
-                    - pimple
+                    []
         steps:
             - uses: actions/checkout@v5
             - name: Build container
@@ -78,11 +76,14 @@ jobs:
             matrix:
                 container:
                     - auryn
+                    - dice.configured
+                    - dice.unconfigured
                     - laravel.cached
                     - laravel.unconfigured
                     - league.predefined
                     - league.unconfigured
                     - phalcon.transient
+                    - pimple
         steps:
             - uses: actions/checkout@v5
             - name: Build container
@@ -232,9 +233,7 @@ jobs:
         strategy:
             matrix:
                 container:
-                    - dice.configured
-                    - dice.unconfigured
-                    - pimple
+                    []
                 test:
                     - f06
                     - f06_startup
@@ -270,9 +269,7 @@ jobs:
         strategy:
             matrix:
                 container:
-                    - dice.configured
-                    - dice.unconfigured
-                    - pimple
+                    []
                 test:
                     - p16
                     - p16_startup
@@ -316,11 +313,14 @@ jobs:
             matrix:
                 container:
                     - auryn
+                    - dice.configured
+                    - dice.unconfigured
                     - laravel.cached
                     - laravel.unconfigured
                     - league.predefined
                     - league.unconfigured
                     - phalcon.transient
+                    - pimple
                 test:
                     - f06
                     - f06_startup

--- a/tools/update_workflow.php
+++ b/tools/update_workflow.php
@@ -33,8 +33,12 @@ function parse_run_summary(string $filename): array {
 }
 
 function replace_container_list(string $workflow, string $job, array $containers): string {
-    $pattern = '/(^    ' . preg_quote($job, '/') . ":\n[\s\S]*?container:\n)(?: {20}- .*?\n)+/m";
-    $replacement = "$1" . implode('', array_map(fn($c) => "                    - $c\n", $containers));
+    $pattern = '/(^    ' . preg_quote($job, '/') . ":\n[\s\S]*?container:\n)(?: {20}- .*?\n| {20}\[\]\n)+/m";
+    if ($containers === []) {
+        $replacement = "$1                    []\n";
+    } else {
+        $replacement = "$1" . implode('', array_map(fn($c) => "                    - $c\n", $containers));
+    }
     return preg_replace($pattern, $replacement, $workflow);
 }
 
@@ -44,14 +48,32 @@ $fast = [];
 $medium = [];
 $slow = [];
 
+$fastThresholds = ['f06' => 0.01, 'p16' => 0.05, 'z26' => 0.5];
+$mediumThresholds = ['f06' => 0.1, 'p16' => 0.5, 'z26' => 5];
+
 foreach ($containers as $container) {
-    $time = $summary[$container]['f06'] ?? null;
-    if ($time === null) {
+    $category = 'fast';
+    $hasMetric = false;
+    foreach (['f06', 'p16', 'z26'] as $metric) {
+        $value = $summary[$container][$metric] ?? null;
+        if ($value !== null && $value > 0) {
+            $hasMetric = true;
+            if ($value >= $mediumThresholds[$metric]) {
+                $category = 'slow';
+                break;
+            }
+            if ($value >= $fastThresholds[$metric] && $category === 'fast') {
+                $category = 'medium';
+            }
+        }
+    }
+    if (!$hasMetric) {
+        $slow[] = $container;
         continue;
     }
-    if ($time < 0.01) {
+    if ($category === 'fast') {
         $fast[] = $container;
-    } elseif ($time <= 0.1) {
+    } elseif ($category === 'medium') {
         $medium[] = $container;
     } else {
         $slow[] = $container;


### PR DESCRIPTION
## Summary
- Relax p16 and z26 thresholds (fast: 0.05/0.5, medium: 0.5/5) so benchmark placement considers slower metrics
- Regenerate workflow with updated container groupings

## Testing
- `php -l tools/update_workflow.php`
- `php tools/update_workflow.php`


------
https://chatgpt.com/codex/tasks/task_e_68bf34287b1c832fbbc5a7e6aeb4e4de

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Bug Fixes
  - None

- Chores
  - Rebalanced CI workflows to optimize test distribution and execution time.
  - Paused select fast/medium job matrices; expanded slow suite coverage with additional variants.
  - Introduced metrics-based categorization to group workloads more accurately.
  - Improved workflow robustness by safely handling empty lists in configuration.

- Documentation
  - None

- Refactor
  - None

- Style
  - None

- Tests
  - None

- Revert
  - None

<!-- end of auto-generated comment: release notes by coderabbit.ai -->