### PR TITLE
Balance workflow categories dynamically

### DIFF
--- a/.github/workflows/update-test-results.yml
+++ b/.github/workflows/update-test-results.yml
@@ -26,11 +26,8 @@ jobs:
         strategy:
             matrix:
                 container:
-                    - aura-di
                     - laminas-servicemanager
-                    - laravel.singletons
                     - nette-di
-                    - phalcon.shared
                     - php-di
                     - quickly.compiled
                     - quickly.configured
@@ -55,7 +52,12 @@ jobs:
         strategy:
             matrix:
                 container:
-                    []
+                    - aura-di
+                    - auryn
+                    - laravel.cached
+                    - laravel.singletons
+                    - phalcon.shared
+                    - phalcon.transient
         steps:
             - uses: actions/checkout@v5
             - name: Build container
@@ -75,14 +77,11 @@ jobs:
         strategy:
             matrix:
                 container:
-                    - auryn
                     - dice.configured
                     - dice.unconfigured
-                    - laravel.cached
                     - laravel.unconfigured
                     - league.predefined
                     - league.unconfigured
-                    - phalcon.transient
                     - pimple
         steps:
             - uses: actions/checkout@v5
@@ -105,11 +104,8 @@ jobs:
         strategy:
             matrix:
                 container:
-                    - aura-di
                     - laminas-servicemanager
-                    - laravel.singletons
                     - nette-di
-                    - phalcon.shared
                     - php-di
                     - quickly.compiled
                     - quickly.configured
@@ -147,11 +143,8 @@ jobs:
         strategy:
             matrix:
                 container:
-                    - aura-di
                     - laminas-servicemanager
-                    - laravel.singletons
                     - nette-di
-                    - phalcon.shared
                     - php-di
                     - quickly.compiled
                     - quickly.configured
@@ -189,11 +182,8 @@ jobs:
         strategy:
             matrix:
                 container:
-                    - aura-di
                     - laminas-servicemanager
-                    - laravel.singletons
                     - nette-di
-                    - phalcon.shared
                     - php-di
                     - quickly.compiled
                     - quickly.configured
@@ -233,7 +223,12 @@ jobs:
         strategy:
             matrix:
                 container:
-                    []
+                    - aura-di
+                    - auryn
+                    - laravel.cached
+                    - laravel.singletons
+                    - phalcon.shared
+                    - phalcon.transient
                 test:
                     - f06
                     - f06_startup
@@ -269,7 +264,12 @@ jobs:
         strategy:
             matrix:
                 container:
-                    []
+                    - aura-di
+                    - auryn
+                    - laravel.cached
+                    - laravel.singletons
+                    - phalcon.shared
+                    - phalcon.transient
                 test:
                     - p16
                     - p16_startup
@@ -312,14 +312,11 @@ jobs:
         strategy:
             matrix:
                 container:
-                    - auryn
                     - dice.configured
                     - dice.unconfigured
-                    - laravel.cached
                     - laravel.unconfigured
                     - league.predefined
                     - league.unconfigured
-                    - phalcon.transient
                     - pimple
                 test:
                     - f06

--- a/tools/update_workflow.php
+++ b/tools/update_workflow.php
@@ -48,32 +48,39 @@ $fast = [];
 $medium = [];
 $slow = [];
 
-$fastThresholds = ['f06' => 0.01, 'p16' => 0.05, 'z26' => 0.5];
-$mediumThresholds = ['f06' => 0.1, 'p16' => 0.5, 'z26' => 5];
+$metrics = ['f06', 'p16', 'z26'];
+$scores = [];
 
 foreach ($containers as $container) {
-    $category = 'fast';
-    $hasMetric = false;
-    foreach (['f06', 'p16', 'z26'] as $metric) {
+    $maxValue = null;
+    foreach ($metrics as $metric) {
         $value = $summary[$container][$metric] ?? null;
         if ($value !== null && $value > 0) {
-            $hasMetric = true;
-            if ($value >= $mediumThresholds[$metric]) {
-                $category = 'slow';
-                break;
-            }
-            if ($value >= $fastThresholds[$metric] && $category === 'fast') {
-                $category = 'medium';
-            }
+            $maxValue = $maxValue === null ? $value : max($maxValue, $value);
         }
     }
-    if (!$hasMetric) {
+    if ($maxValue === null) {
         $slow[] = $container;
+    } else {
+        $scores[$container] = $maxValue;
+    }
+}
+
+$sortedScores = $scores;
+asort($sortedScores);
+$values = array_values($sortedScores);
+$count = count($values);
+$fastThreshold = $values[(int) floor($count / 3)] ?? 0;
+$mediumThreshold = $values[(int) floor(2 * $count / 3)] ?? 0;
+
+foreach ($containers as $container) {
+    $score = $scores[$container] ?? null;
+    if ($score === null) {
         continue;
     }
-    if ($category === 'fast') {
+    if ($score <= $fastThreshold) {
         $fast[] = $container;
-    } elseif ($category === 'medium') {
+    } elseif ($score <= $mediumThreshold) {
         $medium[] = $container;
     } else {
         $slow[] = $container;


### PR DESCRIPTION
## Summary
- Dynamically compute performance thresholds from run summary to balance fast, medium, and slow containers
- Regenerate update-test-results workflow to populate container matrices for each category

## Testing
- `php -l tools/update_workflow.php`
- `php tools/update_workflow.php`


------
https://chatgpt.com/codex/tasks/task_e_68bf45aee41c832f93f934f8f44cc7f8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Rebalanced CI build and benchmark matrices: expanded coverage in medium tiers, reduced redundant variants in fast/slow paths. Overall flow unchanged; only container sets per job adjusted.
- Refactor
  - Switched benchmark categorization to a dynamic, score-based approach using distribution-derived thresholds, yielding more balanced fast/medium/slow groupings. Items without metrics default to slow.
- Tests
  - Enabled broader mid/late-stage benchmark coverage to better reflect realistic performance scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->