### PR TITLE
Implement Zen container config hints

### DIFF
--- a/containers/zen.filebased/AdapterImplementation.php
+++ b/containers/zen.filebased/AdapterImplementation.php
@@ -51,4 +51,12 @@ class ContainerConfig extends AbstractContainerConfig {
             ClassEntryPoint::create(Z26::class),
         ];
     }
+
+    protected function getDefinitionHints(): array {
+        return [];
+    }
+
+    protected function getWildcardHints(): array {
+        return [];
+    }
 }

--- a/containers/zen.unconfigured/AdapterImplementation.php
+++ b/containers/zen.unconfigured/AdapterImplementation.php
@@ -51,4 +51,12 @@ class ContainerConfig extends AbstractContainerConfig {
             ClassEntryPoint::create(Z26::class),
         ];
     }
+
+    protected function getDefinitionHints(): array {
+        return [];
+    }
+
+    protected function getWildcardHints(): array {
+        return [];
+    }
 }


### PR DESCRIPTION
## Summary
- implement `getDefinitionHints` and `getWildcardHints` in Zen container configs

## Testing
- `php -l containers/zen.filebased/AdapterImplementation.php`
- `php -l containers/zen.unconfigured/AdapterImplementation.php`


------
https://chatgpt.com/codex/tasks/task_e_68bfad75df3c832f95ec7a94dabfc680

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Added internal configuration hooks for definition and wildcard hints with no impact on behavior.
* **Chores**
  * Aligned container adapter implementations for consistency; no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->