### PR TITLE
feat: show percentage with two decimal digits

### DIFF
--- a/tools/generate_graphs.php
+++ b/tools/generate_graphs.php
@@ -139,7 +139,7 @@ function create_bar_chart(array $values, string $title, string $filename, array 
             $percentageText = 'skipped due to performance';
         } else {
             $percentage = ($logVal / $maxLog) * 100;
-            $percentageText = sprintf('%.1f%%', $percentage);
+            $percentageText = sprintf('%.2f%%', $percentage);
         }
         $percentageY = (int) ($y1 + ($barHeight - imagefontheight(2)) / 2);
         $percentageX = $x2 + 5;


### PR DESCRIPTION
## Summary
- show percentages near graph bars with two decimal digits

## Testing
- `php -l tools/generate_graphs.php`


------
https://chatgpt.com/codex/tasks/task_e_68c08185fd74832f9deb8f85da0815a3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Bar chart percentage labels now display two decimal places for improved precision and readability.
  * Enhances clarity when comparing close values across charts without altering computations.
  * Visual-only update; no changes to interactions, performance, or underlying data.
  * No API or configuration changes required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->