### PR TITLE
feat: add build step for ray-di compiled container

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ docker run --rm -v "$PWD:/out" di-benchmark-php-di php benchmark.php f06 1
 
 The build step prepares the image for the chosen container, and the run command executes a single run of the specified test (for example, `f06`). The resulting `results.json` file will be written to the current directory.
 
+Some containers perform extra work during the image build; for example, `ray-di.compiled` precompiles its dependencies automatically.
+
 ## 🧩 Containers
 
 | Container | Features |

--- a/containers/ray-di.compiled/AdapterImplementation.php
+++ b/containers/ray-di.compiled/AdapterImplementation.php
@@ -71,10 +71,13 @@ class AdapterImplementation {
             }
         };
         $dir = __DIR__ . '/compiled';
-        (new Compiler())->compile($module, $dir);
+        if (!is_dir($dir)) {
+            (new Compiler())->compile($module, $dir);
+        }
         $this->injector = new CompiledInjector($dir);
     }
     public function get(string $class): object {
         return $this->injector->getInstance($class);
     }
 }
+

--- a/containers/ray-di.compiled/Dockerfile
+++ b/containers/ray-di.compiled/Dockerfile
@@ -9,4 +9,5 @@ RUN apt-get update \
     && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
     && composer install --no-interaction --no-progress
 COPY src/*.php ./
+RUN php build.php
 CMD ["php", "benchmark.php"]

--- a/containers/ray-di.compiled/build.php
+++ b/containers/ray-di.compiled/build.php
@@ -1,0 +1,79 @@
+<?php
+
+use Ray\Compiler\Compiler;
+use Ray\Di\AbstractModule;
+
+require __DIR__ . '/vendor/autoload.php';
+$srcDir = is_dir(__DIR__ . '/src') ? __DIR__ . '/src' : __DIR__ . '/../../src';
+require $srcDir . '/classes-06.php';
+require $srcDir . '/classes-16.php';
+require $srcDir . '/classes-26.php';
+
+$classes = [
+    A06::class,
+    B06::class,
+    C06::class,
+    D06::class,
+    E06::class,
+    F06::class,
+    A16::class,
+    B16::class,
+    C16::class,
+    D16::class,
+    E16::class,
+    F16::class,
+    G16::class,
+    H16::class,
+    I16::class,
+    J16::class,
+    K16::class,
+    L16::class,
+    M16::class,
+    N16::class,
+    O16::class,
+    P16::class,
+    A26::class,
+    B26::class,
+    C26::class,
+    D26::class,
+    E26::class,
+    F26::class,
+    G26::class,
+    H26::class,
+    I26::class,
+    J26::class,
+    K26::class,
+    L26::class,
+    M26::class,
+    N26::class,
+    O26::class,
+    P26::class,
+    Q26::class,
+    R26::class,
+    S26::class,
+    T26::class,
+    U26::class,
+    V26::class,
+    W26::class,
+    X26::class,
+    Y26::class,
+    Z26::class,
+];
+
+$module = new class($classes) extends AbstractModule {
+    /** @var array<int, string> */
+    private array $classes;
+    public function __construct(array $classes) {
+        $this->classes = $classes;
+        parent::__construct();
+    }
+    protected function configure(): void {
+        foreach ($this->classes as $class) {
+            $this->bind($class);
+        }
+    }
+};
+
+$dir = __DIR__ . '/compiled';
+(new Compiler())->compile($module, $dir);
+

--- a/tools/generate_readme.php
+++ b/tools/generate_readme.php
@@ -121,6 +121,8 @@ $lines[] = '```';
 $lines[] = '';
 $lines[] = 'The build step prepares the image for the chosen container, and the run command executes a single run of the specified test (for example, `f06`). The resulting `results.json` file will be written to the current directory.';
 $lines[] = '';
+$lines[] = 'Some containers perform extra work during the image build; for example, `ray-di.compiled` precompiles its dependencies automatically.';
+$lines[] = '';
 $containerTable = [
     'aura-di' => [
         'name' => 'Aura.Di',
@@ -304,3 +306,4 @@ foreach ($tests as $testKey => $info) {
 $lines[] = 'Questions, issues, and new containers are welcome!';
 $lines[] = '';
 file_put_contents('README.md', implode("\n", $lines));
+


### PR DESCRIPTION
## Summary
- add build script to precompile Ray.Di benchmark classes
- skip recompilation when cached files exist
- document build step for ray-di compiled container
- run precompile script during Docker image build

## Testing
- `php -l containers/ray-di.compiled/build.php`
- `php -l containers/ray-di.compiled/AdapterImplementation.php`
- `php -l tools/generate_readme.php`
- `php tools/generate_readme.php`


------
https://chatgpt.com/codex/tasks/task_e_68c082d860b0832f9b34b947a294fea2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The ray-di.compiled container now precompiles dependencies during image build, and will reuse existing compiled artifacts if already present.

* **Documentation**
  * Updated README to clarify that some containers perform extra work during image builds (e.g., dependency precompilation).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->