### PR TITLE
Fix Ray DI build script path detection

### DIFF
--- a/containers/ray-di.compiled/build.php
+++ b/containers/ray-di.compiled/build.php
@@ -4,7 +4,13 @@ use Ray\Compiler\Compiler;
 use Ray\Di\AbstractModule;
 
 require __DIR__ . '/vendor/autoload.php';
-$srcDir = is_dir(__DIR__ . '/src') ? __DIR__ . '/src' : __DIR__ . '/../../src';
+
+$srcDir = __DIR__;
+if (is_dir(__DIR__ . '/src')) {
+    $srcDir = __DIR__ . '/src';
+} elseif (is_dir(__DIR__ . '/../../src')) {
+    $srcDir = __DIR__ . '/../../src';
+}
 require $srcDir . '/classes-06.php';
 require $srcDir . '/classes-16.php';
 require $srcDir . '/classes-26.php';


### PR DESCRIPTION
## Summary
- Allow build script to load classes from its own directory or src fallback

## Testing
- `php -l containers/ray-di.compiled/build.php`


------
https://chatgpt.com/codex/tasks/task_e_68c087af826c832f8bc65b0c5c7ac4fd