### PR TITLE
Precompile Symfony container at build time

### DIFF
--- a/containers/symfony.compiled/AdapterImplementation.php
+++ b/containers/symfony.compiled/AdapterImplementation.php
@@ -1,66 +1,11 @@
 <?php
 
-use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Reference;
+require __DIR__ . '/CompiledContainer.php';
 
 class AdapterImplementation {
-    private ContainerBuilder $container;
+    private CompiledContainer $container;
     public function __construct() {
-        $c = new ContainerBuilder();
-        foreach ([
-            A06::class,
-            B06::class,
-            C06::class,
-            D06::class,
-            E06::class,
-            F06::class,
-            A16::class,
-            B16::class,
-            C16::class,
-            D16::class,
-            E16::class,
-            F16::class,
-            G16::class,
-            H16::class,
-            I16::class,
-            J16::class,
-            K16::class,
-            L16::class,
-            M16::class,
-            N16::class,
-            O16::class,
-            P16::class,
-            A26::class,
-            B26::class,
-            C26::class,
-            D26::class,
-            E26::class,
-            F26::class,
-            G26::class,
-            H26::class,
-            I26::class,
-            J26::class,
-            K26::class,
-            L26::class,
-            M26::class,
-            N26::class,
-            O26::class,
-            P26::class,
-            Q26::class,
-            R26::class,
-            S26::class,
-            T26::class,
-            U26::class,
-            V26::class,
-            W26::class,
-            X26::class,
-            Y26::class,
-            Z26::class,
-        ] as $service) {
-            $c->register($service, $service)->setPublic(true)->setAutowired(true);
-        }
-        $c->compile();
-        $this->container = $c;
+        $this->container = new CompiledContainer();
     }
     public function get(string $class): object {
         return $this->container->get($class);

--- a/containers/symfony.compiled/Dockerfile
+++ b/containers/symfony.compiled/Dockerfile
@@ -9,4 +9,5 @@ RUN apt-get update \
     && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
     && composer install --no-interaction --no-progress
 COPY src/*.php ./
+RUN php build.php
 CMD ["php", "benchmark.php"]

--- a/containers/symfony.compiled/build.php
+++ b/containers/symfony.compiled/build.php
@@ -1,0 +1,67 @@
+<?php
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Dumper\PhpDumper;
+
+require __DIR__ . '/vendor/autoload.php';
+require __DIR__ . '/classes-06.php';
+require __DIR__ . '/classes-16.php';
+require __DIR__ . '/classes-26.php';
+
+$container = new ContainerBuilder();
+foreach ([
+    A06::class,
+    B06::class,
+    C06::class,
+    D06::class,
+    E06::class,
+    F06::class,
+    A16::class,
+    B16::class,
+    C16::class,
+    D16::class,
+    E16::class,
+    F16::class,
+    G16::class,
+    H16::class,
+    I16::class,
+    J16::class,
+    K16::class,
+    L16::class,
+    M16::class,
+    N16::class,
+    O16::class,
+    P16::class,
+    A26::class,
+    B26::class,
+    C26::class,
+    D26::class,
+    E26::class,
+    F26::class,
+    G26::class,
+    H26::class,
+    I26::class,
+    J26::class,
+    K26::class,
+    L26::class,
+    M26::class,
+    N26::class,
+    O26::class,
+    P26::class,
+    Q26::class,
+    R26::class,
+    S26::class,
+    T26::class,
+    U26::class,
+    V26::class,
+    W26::class,
+    X26::class,
+    Y26::class,
+    Z26::class,
+] as $service) {
+    $container->register($service, $service)->setPublic(true)->setAutowired(true);
+}
+$container->compile();
+
+$dumper = new PhpDumper($container);
+file_put_contents(__DIR__ . '/CompiledContainer.php', $dumper->dump(['class' => 'CompiledContainer']));


### PR DESCRIPTION
## Summary
- Compile Symfony container during image build
- Load precompiled container at runtime

## Testing
- `php -l containers/symfony.compiled/AdapterImplementation.php`
- `php -l containers/symfony.compiled/build.php`


------
https://chatgpt.com/codex/tasks/task_e_68c091081664832f846e539da73dc6d9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Switched to a precompiled dependency container, reducing runtime overhead and significantly improving application startup and request performance. No changes to public APIs.
- Chores
  - Added a build step to generate the compiled container during image creation, ensuring consistent, reproducible builds and faster runtime initialization.
  - Introduced a build script to automate container compilation, contributing to more reliable deployments and potential memory footprint improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->