### PR TITLE
Remove runtime compilation from Ray DI compiled container

### DIFF
--- a/containers/ray-di.compiled/AdapterImplementation.php
+++ b/containers/ray-di.compiled/AdapterImplementation.php
@@ -1,79 +1,11 @@
 <?php
 
 use Ray\Compiler\CompiledInjector;
-use Ray\Compiler\Compiler;
-use Ray\Di\AbstractModule;
 
 class AdapterImplementation {
     private CompiledInjector $injector;
     public function __construct() {
-        $classes = [
-            A06::class,
-            B06::class,
-            C06::class,
-            D06::class,
-            E06::class,
-            F06::class,
-            A16::class,
-            B16::class,
-            C16::class,
-            D16::class,
-            E16::class,
-            F16::class,
-            G16::class,
-            H16::class,
-            I16::class,
-            J16::class,
-            K16::class,
-            L16::class,
-            M16::class,
-            N16::class,
-            O16::class,
-            P16::class,
-            A26::class,
-            B26::class,
-            C26::class,
-            D26::class,
-            E26::class,
-            F26::class,
-            G26::class,
-            H26::class,
-            I26::class,
-            J26::class,
-            K26::class,
-            L26::class,
-            M26::class,
-            N26::class,
-            O26::class,
-            P26::class,
-            Q26::class,
-            R26::class,
-            S26::class,
-            T26::class,
-            U26::class,
-            V26::class,
-            W26::class,
-            X26::class,
-            Y26::class,
-            Z26::class,
-        ];
-        $module = new class($classes) extends AbstractModule {
-            /** @var array<int, string> */
-            private array $classes;
-            public function __construct(array $classes) {
-                $this->classes = $classes;
-                parent::__construct();
-            }
-            protected function configure(): void {
-                foreach ($this->classes as $class) {
-                    $this->bind($class);
-                }
-            }
-        };
         $dir = __DIR__ . '/compiled';
-        if (!is_dir($dir)) {
-            (new Compiler())->compile($module, $dir);
-        }
         $this->injector = new CompiledInjector($dir);
     }
     public function get(string $class): object {


### PR DESCRIPTION
## Summary
- Remove runtime compilation logic from Ray DI compiled container

## Testing
- `php -l containers/ray-di.compiled/AdapterImplementation.php`

------
https://chatgpt.com/codex/tasks/task_e_68c0983cd248832fb0928f92d5859808

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Streamlined adapter initialization to use precompiled dependencies, reducing startup time and runtime overhead. Behavior remains the same with no changes to public APIs.
- Chores
  - Removed unused compilation-related components and configuration to simplify the runtime environment and reduce maintenance.
- Notes
  - Backward compatible: no changes to method signatures or user-facing behavior.
  - Users may notice faster and more consistent startup across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->