### PR TITLE
fix: update Dockerfile paths to renamed directories

### DIFF
--- a/containers/aura-di.configured.transient/Dockerfile
+++ b/containers/aura-di.configured.transient/Dockerfile
@@ -2,7 +2,7 @@ FROM php:8.4-cli
 
 WORKDIR /app
 RUN mkdir /out
-COPY containers/aura-di/* ./
+COPY containers/aura-di.configured.transient/* ./
 RUN apt-get update \
     && apt-get install -y --no-install-recommends git unzip \
     && rm -rf /var/lib/apt/lists/* \

--- a/containers/auryn.reflection.transient/Dockerfile
+++ b/containers/auryn.reflection.transient/Dockerfile
@@ -2,7 +2,7 @@ FROM php:8.4-cli
 
 WORKDIR /app
 RUN mkdir /out
-COPY containers/auryn/* ./
+COPY containers/auryn.reflection.transient/* ./
 RUN apt-get update \
     && apt-get install -y --no-install-recommends git unzip \
     && rm -rf /var/lib/apt/lists/* \

--- a/containers/dice.configured.singleton/Dockerfile
+++ b/containers/dice.configured.singleton/Dockerfile
@@ -2,7 +2,7 @@ FROM php:8.4-cli
 
 WORKDIR /app
 RUN mkdir /out
-COPY containers/dice.configured/* ./
+COPY containers/dice.configured.singleton/* ./
 RUN apt-get update \
     && apt-get install -y --no-install-recommends git unzip \
     && rm -rf /var/lib/apt/lists/* \

--- a/containers/dice.reflection.transient/Dockerfile
+++ b/containers/dice.reflection.transient/Dockerfile
@@ -2,7 +2,7 @@ FROM php:8.4-cli
 
 WORKDIR /app
 RUN mkdir /out
-COPY containers/dice.unconfigured/* ./
+COPY containers/dice.reflection.transient/* ./
 RUN apt-get update \
     && apt-get install -y --no-install-recommends git unzip \
     && rm -rf /var/lib/apt/lists/* \

--- a/containers/laminas-servicemanager.reflection.singleton/Dockerfile
+++ b/containers/laminas-servicemanager.reflection.singleton/Dockerfile
@@ -2,7 +2,7 @@ FROM php:8.4-cli
 
 WORKDIR /app
 RUN mkdir /out
-COPY containers/laminas-servicemanager/* ./
+COPY containers/laminas-servicemanager.reflection.singleton/* ./
 RUN apt-get update \
     && apt-get install -y --no-install-recommends git unzip \
     && rm -rf /var/lib/apt/lists/* \

--- a/containers/laravel.configured.transient/Dockerfile
+++ b/containers/laravel.configured.transient/Dockerfile
@@ -2,7 +2,7 @@ FROM php:8.4-cli
 
 WORKDIR /app
 RUN mkdir /out
-COPY containers/laravel.cached/* ./
+COPY containers/laravel.configured.transient/* ./
 RUN apt-get update \
     && apt-get install -y --no-install-recommends git unzip \
     && rm -rf /var/lib/apt/lists/* \

--- a/containers/laravel.reflection.singleton/Dockerfile
+++ b/containers/laravel.reflection.singleton/Dockerfile
@@ -2,7 +2,7 @@ FROM php:8.4-cli
 
 WORKDIR /app
 RUN mkdir /out
-COPY containers/laravel.singletons/* ./
+COPY containers/laravel.reflection.singleton/* ./
 RUN apt-get update \
     && apt-get install -y --no-install-recommends git unzip \
     && rm -rf /var/lib/apt/lists/* \

--- a/containers/laravel.reflection.transient/Dockerfile
+++ b/containers/laravel.reflection.transient/Dockerfile
@@ -2,7 +2,7 @@ FROM php:8.4-cli
 
 WORKDIR /app
 RUN mkdir /out
-COPY containers/laravel.unconfigured/* ./
+COPY containers/laravel.reflection.transient/* ./
 RUN apt-get update \
     && apt-get install -y --no-install-recommends git unzip \
     && rm -rf /var/lib/apt/lists/* \

--- a/containers/league.configured.transient/Dockerfile
+++ b/containers/league.configured.transient/Dockerfile
@@ -2,7 +2,7 @@ FROM php:8.4-cli
 
 WORKDIR /app
 RUN mkdir /out
-COPY containers/league.predefined/* ./
+COPY containers/league.configured.transient/* ./
 RUN apt-get update \
     && apt-get install -y --no-install-recommends git unzip \
     && rm -rf /var/lib/apt/lists/* \

--- a/containers/league.reflection.transient/Dockerfile
+++ b/containers/league.reflection.transient/Dockerfile
@@ -2,7 +2,7 @@ FROM php:8.4-cli
 
 WORKDIR /app
 RUN mkdir /out
-COPY containers/league.unconfigured/* ./
+COPY containers/league.reflection.transient/* ./
 RUN apt-get update \
     && apt-get install -y --no-install-recommends git unzip \
     && rm -rf /var/lib/apt/lists/* \

--- a/containers/nette-di.compiled.singleton/Dockerfile
+++ b/containers/nette-di.compiled.singleton/Dockerfile
@@ -2,7 +2,7 @@ FROM php:8.4-cli
 
 WORKDIR /app
 RUN mkdir /out
-COPY containers/nette-di/* ./
+COPY containers/nette-di.compiled.singleton/* ./
 RUN apt-get update \
     && apt-get install -y --no-install-recommends git unzip \
     && rm -rf /var/lib/apt/lists/* \

--- a/containers/phalcon.configured.singleton/Dockerfile
+++ b/containers/phalcon.configured.singleton/Dockerfile
@@ -2,7 +2,7 @@ FROM php:8.4-cli
 
 WORKDIR /app
 RUN mkdir /out
-COPY containers/phalcon.shared/* ./
+COPY containers/phalcon.configured.singleton/* ./
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 
 RUN chmod +x /usr/local/bin/install-php-extensions \

--- a/containers/phalcon.configured.transient/Dockerfile
+++ b/containers/phalcon.configured.transient/Dockerfile
@@ -2,7 +2,7 @@ FROM php:8.4-cli
 
 WORKDIR /app
 RUN mkdir /out
-COPY containers/phalcon.transient/* ./
+COPY containers/phalcon.configured.transient/* ./
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 
 RUN chmod +x /usr/local/bin/install-php-extensions \

--- a/containers/php-di.reflection.singleton/Dockerfile
+++ b/containers/php-di.reflection.singleton/Dockerfile
@@ -2,7 +2,7 @@ FROM php:8.4-cli
 
 WORKDIR /app
 RUN mkdir /out
-COPY containers/php-di/* ./
+COPY containers/php-di.reflection.singleton/* ./
 RUN apt-get update \
     && apt-get install -y --no-install-recommends git unzip \
     && rm -rf /var/lib/apt/lists/* \

--- a/containers/pimple.configured.singleton/Dockerfile
+++ b/containers/pimple.configured.singleton/Dockerfile
@@ -2,7 +2,7 @@ FROM php:8.4-cli
 
 WORKDIR /app
 RUN mkdir /out
-COPY containers/pimple.singletons/* ./
+COPY containers/pimple.configured.singleton/* ./
 RUN apt-get update \
     && apt-get install -y --no-install-recommends git unzip \
     && rm -rf /var/lib/apt/lists/* \

--- a/containers/pimple.configured.transient/Dockerfile
+++ b/containers/pimple.configured.transient/Dockerfile
@@ -2,7 +2,7 @@ FROM php:8.4-cli
 
 WORKDIR /app
 RUN mkdir /out
-COPY containers/pimple.factories/* ./
+COPY containers/pimple.configured.transient/* ./
 RUN apt-get update \
     && apt-get install -y --no-install-recommends git unzip \
     && rm -rf /var/lib/apt/lists/* \

--- a/containers/quickly.compiled.singleton/Dockerfile
+++ b/containers/quickly.compiled.singleton/Dockerfile
@@ -2,10 +2,10 @@ FROM php:8.4-cli
 
 WORKDIR /app
 RUN mkdir /out
-COPY containers/quickly.compiled/* ./
+COPY containers/quickly.compiled.singleton/* ./
 COPY src/*.php ./
 RUN mkdir .quickly
-COPY containers/quickly.compiled/.quickly/entrypoints.php ./.quickly/entrypoints.php
+COPY containers/quickly.compiled.singleton/.quickly/entrypoints.php ./.quickly/entrypoints.php
 RUN apt-get update \
     && apt-get install -y --no-install-recommends git unzip \
     && rm -rf /var/lib/apt/lists/* \

--- a/containers/quickly.configured.singleton/Dockerfile
+++ b/containers/quickly.configured.singleton/Dockerfile
@@ -2,10 +2,10 @@ FROM php:8.4-cli
 
 WORKDIR /app
 RUN mkdir /out
-COPY containers/quickly.configured/* ./
+COPY containers/quickly.configured.singleton/* ./
 COPY src/*.php ./
 RUN mkdir .quickly
-COPY containers/quickly.configured/.quickly/entrypoints.php ./.quickly/entrypoints.php
+COPY containers/quickly.configured.singleton/.quickly/entrypoints.php ./.quickly/entrypoints.php
 RUN apt-get update \
     && apt-get install -y --no-install-recommends git unzip \
     && rm -rf /var/lib/apt/lists/* \

--- a/containers/quickly.reflection.singleton/Dockerfile
+++ b/containers/quickly.reflection.singleton/Dockerfile
@@ -2,7 +2,7 @@ FROM php:8.4-cli
 
 WORKDIR /app
 RUN mkdir /out
-COPY containers/quickly.reflection/* ./
+COPY containers/quickly.reflection.singleton/* ./
 RUN apt-get update \
     && apt-get install -y --no-install-recommends git unzip \
     && rm -rf /var/lib/apt/lists/* \

--- a/containers/ray-di.compiled.transient/Dockerfile
+++ b/containers/ray-di.compiled.transient/Dockerfile
@@ -2,7 +2,7 @@ FROM php:8.4-cli
 
 WORKDIR /app
 RUN mkdir /out
-COPY containers/ray-di.compiled/* ./
+COPY containers/ray-di.compiled.transient/* ./
 RUN apt-get update \
     && apt-get install -y --no-install-recommends git unzip \
     && rm -rf /var/lib/apt/lists/* \

--- a/containers/ray-di.reflection.transient/Dockerfile
+++ b/containers/ray-di.reflection.transient/Dockerfile
@@ -2,7 +2,7 @@ FROM php:8.4-cli
 
 WORKDIR /app
 RUN mkdir /out
-COPY containers/ray-di.unconfigured/* ./
+COPY containers/ray-di.reflection.transient/* ./
 RUN apt-get update \
     && apt-get install -y --no-install-recommends git unzip \
     && rm -rf /var/lib/apt/lists/* \

--- a/containers/symfony.compiled.singleton/Dockerfile
+++ b/containers/symfony.compiled.singleton/Dockerfile
@@ -2,7 +2,7 @@ FROM php:8.4-cli
 
 WORKDIR /app
 RUN mkdir /out
-COPY containers/symfony.compiled/* ./
+COPY containers/symfony.compiled.singleton/* ./
 RUN apt-get update \
     && apt-get install -y --no-install-recommends git unzip \
     && rm -rf /var/lib/apt/lists/* \

--- a/containers/zen.compiled.singleton/Dockerfile
+++ b/containers/zen.compiled.singleton/Dockerfile
@@ -2,7 +2,7 @@ FROM php:8.4-cli
 
 WORKDIR /app
 RUN mkdir /out
-COPY containers/zen.unconfigured/* ./
+COPY containers/zen.compiled.singleton/* ./
 RUN apt-get update \
     && apt-get install -y --no-install-recommends git unzip \
     && rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
## Summary
- align container Dockerfiles with renamed directories by updating COPY paths

## Testing
- `rg "COPY containers" -n`


------
https://chatgpt.com/codex/tasks/task_e_68c0e6958460832f934dd32f76e9cbe4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Several containers now install Composer and preinstall dependencies during build, enabling ready-to-run images.
  - Quickly (compiled) image now builds during image creation and sets a default run command; entrypoints updated for Quickly variants.

- Chores
  - Standardized Dockerfile COPY sources to variant-specific contexts across multiple containers (e.g., configured/transient, reflection/compiled/singleton) for consistent image contents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->