### PR TITLE
Cache php baseline instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,13 @@ Some containers perform extra work during the image build; for example, `ray-di.
 | [Laminas ServiceManager](https://github.com/laminas/laminas-servicemanager) | Factory-driven dependency injection container |
 | [League Container](https://github.com/thephpleague/container) | A fast and intuitive dependency injection container. |
 | [Phalcon](https://github.com/phalcon/cphalcon) | A PHP extension built for performance |
-| [PHP (baseline)](https://www.php.net/) | Manual instantiation of dependencies without a container |
+| [PHP (baseline)](https://www.php.net/) | Manual instantiation of dependencies with simple caching |
 | [Quickly](https://github.com/Idrinth/quickly) | A fast dependency injection container featuring build time resolution. |
 | [Ray.Di](https://github.com/ray-di/Ray.Di) | DI and AOP framework for PHP inspired by Google Guice |
 | [Zen](https://github.com/woohoolabs/zen) | Woohoo Labs. Zen DI Container and preload file generator |
 ## Latest Results
 
-Run from 2025-09-09
+Run from 2025-09-10
 
 ### 📊 f06
 

--- a/containers/php-baseline/AdapterImplementation.php
+++ b/containers/php-baseline/AdapterImplementation.php
@@ -1,13 +1,19 @@
 <?php
 
 class AdapterImplementation {
+    private array $cache = [];
+
     public function get(string $class): object {
-        return match ($class) {
-            F06::class => $this->createF06(),
-            P16::class => $this->createP16(),
-            Z26::class => $this->createZ26(),
-            default => throw new InvalidArgumentException("Unknown class {$class}"),
-        };
+        if (!isset($this->cache[$class])) {
+            $this->cache[$class] = match ($class) {
+                F06::class => $this->createF06(),
+                P16::class => $this->createP16(),
+                Z26::class => $this->createZ26(),
+                default => throw new InvalidArgumentException("Unknown class {$class}"),
+            };
+        }
+
+        return $this->cache[$class];
     }
 
     private function createF06(): F06 {

--- a/tools/generate_readme.php
+++ b/tools/generate_readme.php
@@ -184,7 +184,7 @@ $containerTable = [
     'php-baseline' => [
         'name' => 'PHP (baseline)',
         'url' => 'https://www.php.net/',
-        'features' => 'Manual instantiation of dependencies without a container',
+        'features' => 'Manual instantiation of dependencies with simple caching',
     ],
     'quickly' => [
         'name' => 'Quickly',


### PR DESCRIPTION
## Summary
- cache php baseline adapter instances
- document php baseline's caching behavior
- use `isset` for baseline cache lookups

## Testing
- `php tools/generate_readme.php`
- `php -l containers/php-baseline/AdapterImplementation.php`
- `php -l tools/generate_readme.php`


------
https://chatgpt.com/codex/tasks/task_e_68c0ea9858d8832f8092492b03c5b193