### PR TITLE
List run combinations in container table

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,26 +44,26 @@ Some containers perform extra work during the image build; for example, `ray-di.
 
 ## 🧩 Containers
 
-| Container | Features |
-| --- | --- |
-| [Aura.Di](https://github.com/auraphp/Aura.Di) | Configurable DI container with lazy loading and service factories |
-| [PHP-DI](https://github.com/PHP-DI/PHP-DI) | Autowiring, annotations, and compiled container support |
-| [Pimple](https://github.com/silexphp/Pimple) | Lightweight closure-based container |
-| [Symfony DI](https://github.com/symfony/dependency-injection) | Feature-rich container with configuration and compilation |
-| [Laravel Container](https://github.com/laravel/framework) | Framework-integrated container with automatic resolution and binding |
-| [Nette DI](https://github.com/nette/di) | High-performance compiled container |
-| [Auryn](https://github.com/rdlowrey/auryn) | Auryn is a dependency injector for bootstrapping object-oriented PHP applications. |
-| [Dice](https://github.com/Level-2/Dice) | A minimalist dependency injection container for PHP. |
-| [Laminas ServiceManager](https://github.com/laminas/laminas-servicemanager) | Factory-driven dependency injection container |
-| [League Container](https://github.com/thephpleague/container) | A fast and intuitive dependency injection container. |
-| [Phalcon](https://github.com/phalcon/cphalcon) | A PHP extension built for performance |
-| [PHP (baseline)](https://www.php.net/) | Manual instantiation of dependencies without a container |
-| [Quickly](https://github.com/Idrinth/quickly) | A fast dependency injection container featuring build time resolution. |
-| [Ray.Di](https://github.com/ray-di/Ray.Di) | DI and AOP framework for PHP inspired by Google Guice |
-| [Zen](https://github.com/woohoolabs/zen) | Woohoo Labs. Zen DI Container and preload file generator |
+| Name+Link | Run combinations | Description |
+| --- | --- | --- |
+| [Aura.Di](https://github.com/auraphp/Aura.Di) | configured transient | Configurable DI container with lazy loading and service factories |
+| [PHP-DI](https://github.com/PHP-DI/PHP-DI) | reflection singleton | Autowiring, annotations, and compiled container support |
+| [Pimple](https://github.com/silexphp/Pimple) | configured singleton, configured transient | Lightweight closure-based container |
+| [Symfony DI](https://github.com/symfony/dependency-injection) | compiled singleton | Feature-rich container with configuration and compilation |
+| [Laravel Container](https://github.com/laravel/framework) | configured transient, reflection singleton, reflection transient | Framework-integrated container with automatic resolution and binding |
+| [Nette DI](https://github.com/nette/di) | compiled singleton | High-performance compiled container |
+| [Auryn](https://github.com/rdlowrey/auryn) | reflection transient | Auryn is a dependency injector for bootstrapping object-oriented PHP applications. |
+| [Dice](https://github.com/Level-2/Dice) | configured singleton, reflection transient | A minimalist dependency injection container for PHP. |
+| [Laminas ServiceManager](https://github.com/laminas/laminas-servicemanager) | reflection singleton | Factory-driven dependency injection container |
+| [League Container](https://github.com/thephpleague/container) | configured transient, reflection transient | A fast and intuitive dependency injection container. |
+| [Phalcon](https://github.com/phalcon/cphalcon) | configured singleton, configured transient | A PHP extension built for performance |
+| [PHP (baseline)](https://www.php.net/) |  | Manual instantiation of dependencies without a container |
+| [Quickly](https://github.com/Idrinth/quickly) | compiled singleton, configured singleton, reflection singleton | A fast dependency injection container featuring build time resolution. |
+| [Ray.Di](https://github.com/ray-di/Ray.Di) | compiled transient, reflection transient | DI and AOP framework for PHP inspired by Google Guice |
+| [Zen](https://github.com/woohoolabs/zen) | compiled singleton | Woohoo Labs. Zen DI Container and preload file generator |
 ## Latest Results
 
-Run from 2025-09-09
+Run from 2025-09-10
 
 ### 📊 f06
 

--- a/tools/generate_readme.php
+++ b/tools/generate_readme.php
@@ -214,20 +214,39 @@ if ($detected !== '') {
         }
     }
 }
+$containerRuns = [];
+foreach (array_keys($data['results'] ?? []) as $containerName) {
+    $parts = explode('.', $containerName);
+    $base = array_shift($parts);
+    if (!isset($containerRuns[$base])) {
+        $containerRuns[$base] = [];
+    }
+    if (count($parts) >= 2) {
+        $combo = $parts[0] . ' ' . $parts[1];
+    } elseif (count($parts) === 1) {
+        $combo = $parts[0];
+    } else {
+        $combo = '';
+    }
+    if ($combo !== '' && !in_array($combo, $containerRuns[$base], true)) {
+        $containerRuns[$base][] = $combo;
+    }
+}
+foreach ($containerRuns as &$runs) {
+    sort($runs);
+}
+unset($runs);
 $lines[] = '## 🧩 Containers';
 $lines[] = '';
-$lines[] = '| Container | Features |';
-$lines[] = '| --- | --- |';
-foreach ($containerTable as $info) {
+$lines[] = '| Name+Link | Run combinations | Description |';
+$lines[] = '| --- | --- | --- |';
+foreach ($containerTable as $key => $info) {
     $name = $info['name'];
     if ($info['url'] !== '') {
         $name = '[' . $name . '](' . $info['url'] . ')';
     }
-    if ($info['features'] === '') {
-        $lines[] = '| ' . $name . ' | |';
-    } else {
-        $lines[] = '| ' . $name . ' | ' . $info['features'] . ' |';
-    }
+    $runText = isset($containerRuns[$key]) ? implode(', ', $containerRuns[$key]) : '';
+    $lines[] = '| ' . $name . ' | ' . $runText . ' | ' . $info['features'] . ' |';
 }
 $lines[] = '## Latest Results';
 $lines[] = '';


### PR DESCRIPTION
## Summary
- Display run combinations for each container in the README
- Parse run combinations from benchmark results and include them in README generation script

## Testing
- `php -l tools/generate_readme.php`
- `php tools/generate_readme.php`


------
https://chatgpt.com/codex/tasks/task_e_68c0ec0428f0832f8a22aedee9f58fb4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Redesigned the Containers table to three columns: Name (linked), Run combinations, and Description.
  - Clarified descriptions (e.g., baseline now “manual instantiation without a container”).
  - Added explicit run combinations per container (e.g., Symfony DI: compiled singleton; Laravel: configured/reflection transient/singleton; PHP-DI: reflection singleton; Nette DI: compiled singleton; Quickly: compiled/configured/reflection singleton; Ray.Di: compiled/reflection transient).
  - Ensured combinations are deduplicated, sorted, and shown only where applicable for clearer comparison.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->