### PR TITLE
Expand DI containers for interface tests

### DIFF
--- a/containers/aura-di.configured.transient/AdapterImplementation.php
+++ b/containers/aura-di.configured.transient/AdapterImplementation.php
@@ -10,6 +10,13 @@ class AdapterImplementation {
         $c->set(F06::class, $c->lazyNew(F06::class));
         $c->set(P16::class, $c->lazyNew(P16::class));
         $c->set(Z26::class, $c->lazyNew(Z26::class));
+        foreach ([['F', '06'], ['P', '16'], ['Z', '26']] as [$max, $suffix]) {
+            foreach (range('A', $max) as $letter) {
+                $interface = $letter . 'In' . $suffix;
+                $implementation = $letter . 'Im' . $suffix;
+                $c->set($interface, $c->lazyNew($implementation));
+            }
+        }
         $this->container = $c;
     }
     public function get(string $class): object {

--- a/containers/dice.configured.singleton/AdapterImplementation.php
+++ b/containers/dice.configured.singleton/AdapterImplementation.php
@@ -62,6 +62,23 @@ class AdapterImplementation {
                 ['shared' => true,'constructParams' => array_map(fn($d) => [Dice::INSTANCE => $d], $deps)]
             );
         }
+        $interfaces = [];
+        foreach ($definitions as $class => $deps) {
+            $iface = substr($class, 0, 1) . 'In' . substr($class, 1);
+            $impl = substr($class, 0, 1) . 'Im' . substr($class, 1);
+            $ifaceDeps = array_map(fn($d) => substr($d, 0, 1) . 'In' . substr($d, 1), $deps);
+            $interfaces[$iface] = [$impl, $ifaceDeps];
+        }
+        foreach ($interfaces as $iface => [$impl, $deps]) {
+            $this->container->addRule(
+                $iface,
+                [
+                    'shared' => true,
+                    'instanceOf' => $impl,
+                    'constructParams' => array_map(fn($d) => [Dice::INSTANCE => $d], $deps),
+                ]
+            );
+        }
     }
     public function get(string $class): object {
         return $this->container->create($class);

--- a/containers/laravel.configured.transient/AdapterImplementation.php
+++ b/containers/laravel.configured.transient/AdapterImplementation.php
@@ -65,6 +65,22 @@ class AdapterImplementation {
                 return new $class(...$args);
             });
         }
+        $interfaces = [];
+        foreach ($definitions as $class => $deps) {
+            $iface = substr($class, 0, 1) . 'In' . substr($class, 1);
+            $impl = substr($class, 0, 1) . 'Im' . substr($class, 1);
+            $ifaceDeps = array_map(fn($d) => substr($d, 0, 1) . 'In' . substr($d, 1), $deps);
+            $interfaces[$iface] = [$impl, $ifaceDeps];
+        }
+        foreach ($interfaces as $iface => [$impl, $deps]) {
+            $c->bind($iface, function ($c) use ($impl, $deps) {
+                $args = [];
+                foreach ($deps as $dep) {
+                    $args[] = $c->make($dep);
+                }
+                return new $impl(...$args);
+            });
+        }
         $this->container = $c;
     }
     public function get(string $class): object {

--- a/containers/league.configured.transient/AdapterImplementation.php
+++ b/containers/league.configured.transient/AdapterImplementation.php
@@ -62,6 +62,19 @@ class AdapterImplementation {
                 $def->addArgument($dep);
             }
         }
+        $interfaces = [];
+        foreach ($definitions as $class => $deps) {
+            $iface = substr($class, 0, 1) . 'In' . substr($class, 1);
+            $impl = substr($class, 0, 1) . 'Im' . substr($class, 1);
+            $ifaceDeps = array_map(fn($d) => substr($d, 0, 1) . 'In' . substr($d, 1), $deps);
+            $interfaces[$iface] = [$impl, $ifaceDeps];
+        }
+        foreach ($interfaces as $iface => [$impl, $deps]) {
+            $def = $c->add($iface, $impl)->setShared(false);
+            foreach ($deps as $dep) {
+                $def->addArgument($dep);
+            }
+        }
         $this->container = $c;
     }
     public function get(string $class): object {

--- a/containers/quickly.compiled.singleton/.quickly/entrypoints.php
+++ b/containers/quickly.compiled.singleton/.quickly/entrypoints.php
@@ -2,6 +2,9 @@
 
 return [
     F06::class,
+    FIn06::class,
     P16::class,
+    PIn16::class,
     Z26::class,
+    ZIn26::class,
 ];

--- a/containers/quickly.configured.singleton/.quickly/entrypoints.php
+++ b/containers/quickly.configured.singleton/.quickly/entrypoints.php
@@ -2,7 +2,10 @@
 
 return [
     F06::class,
+    FIn06::class,
     P16::class,
+    PIn16::class,
     Z26::class,
+    ZIn26::class,
 ];
 

--- a/containers/symfony.compiled.singleton/build.php
+++ b/containers/symfony.compiled.singleton/build.php
@@ -7,6 +7,9 @@ require __DIR__ . '/vendor/autoload.php';
 require __DIR__ . '/classes-06.php';
 require __DIR__ . '/classes-16.php';
 require __DIR__ . '/classes-26.php';
+require __DIR__ . '/interfaces-06.php';
+require __DIR__ . '/interfaces-16.php';
+require __DIR__ . '/interfaces-26.php';
 
 $container = new ContainerBuilder();
 foreach ([
@@ -60,6 +63,14 @@ foreach ([
     Z26::class,
 ] as $service) {
     $container->register($service, $service)->setPublic(true)->setAutowired(true);
+}
+$interfaceGroups = [['F', '06'], ['P', '16'], ['Z', '26']];
+foreach ($interfaceGroups as [$max, $suffix]) {
+    foreach (range('A', $max) as $letter) {
+        $interface = $letter . 'In' . $suffix;
+        $implementation = $letter . 'Im' . $suffix;
+        $container->register($interface, $implementation)->setPublic(true)->setAutowired(true);
+    }
 }
 $container->compile();
 


### PR DESCRIPTION
## Summary
- map interfaces to implementations in several configured containers
- include interface entrypoints for Quickly containers
- register interfaces in Symfony compiled container build

## Testing
- `php -l containers/aura-di.configured.transient/AdapterImplementation.php`
- `php -l containers/dice.configured.singleton/AdapterImplementation.php`
- `php -l containers/laravel.configured.transient/AdapterImplementation.php`
- `php -l containers/league.configured.transient/AdapterImplementation.php`
- `php -l containers/quickly.configured.singleton/.quickly/entrypoints.php`
- `php -l containers/quickly.compiled.singleton/.quickly/entrypoints.php`
- `php -l containers/symfony.compiled.singleton/build.php`


------
https://chatgpt.com/codex/tasks/task_e_68c0eccca11c832faca1aca1ef62ffcb