### PR TITLE
Generate workflow from scratch

### DIFF
--- a/proposed-workflow.yml
+++ b/proposed-workflow.yml
@@ -36,16 +36,14 @@ jobs:
         steps:
             - uses: actions/checkout@v5
             - name: Build container
-              run: |
-                  docker build -t di-benchmark-${{ matrix.container }} \
-                      -f containers/${{ matrix.container }}/Dockerfile .
-                  docker save di-benchmark-${{ matrix.container }} \
-                      -o di-benchmark-${{ matrix.container }}.tar
+                run: |
+                    docker build -t di-benchmark-${{ matrix.container }} -f containers/${{ matrix.container }}/Dockerfile .
+                    docker save di-benchmark-${{ matrix.container }} -o di-benchmark-${{ matrix.container }}.tar
             - name: Upload image
-              uses: actions/upload-artifact@v4
-              with:
-                  name: di-benchmark-${{ matrix.container }}
-                  path: di-benchmark-${{ matrix.container }}.tar
+                uses: actions/upload-artifact@v4
+                with:
+                    name: di-benchmark-${{ matrix.container }}
+                    path: di-benchmark-${{ matrix.container }}.tar
     build-medium:
         if: github.actor != 'github-actions[bot]'
         runs-on: ubuntu-latest
@@ -63,16 +61,14 @@ jobs:
         steps:
             - uses: actions/checkout@v5
             - name: Build container
-              run: |
-                  docker build -t di-benchmark-${{ matrix.container }} \
-                      -f containers/${{ matrix.container }}/Dockerfile .
-                  docker save di-benchmark-${{ matrix.container }} \
-                      -o di-benchmark-${{ matrix.container }}.tar
+                run: |
+                    docker build -t di-benchmark-${{ matrix.container }} -f containers/${{ matrix.container }}/Dockerfile .
+                    docker save di-benchmark-${{ matrix.container }} -o di-benchmark-${{ matrix.container }}.tar
             - name: Upload image
-              uses: actions/upload-artifact@v4
-              with:
-                  name: di-benchmark-${{ matrix.container }}
-                  path: di-benchmark-${{ matrix.container }}.tar
+                uses: actions/upload-artifact@v4
+                with:
+                    name: di-benchmark-${{ matrix.container }}
+                    path: di-benchmark-${{ matrix.container }}.tar
     build-slow:
         if: github.actor != 'github-actions[bot]'
         runs-on: ubuntu-latest
@@ -89,17 +85,14 @@ jobs:
         steps:
             - uses: actions/checkout@v5
             - name: Build container
-              run: |
-                  docker build -t di-benchmark-${{ matrix.container }} \
-                      -f containers/${{ matrix.container }}/Dockerfile .
-                  docker save di-benchmark-${{ matrix.container }} \
-                      -o di-benchmark-${{ matrix.container }}.tar
+                run: |
+                    docker build -t di-benchmark-${{ matrix.container }} -f containers/${{ matrix.container }}/Dockerfile .
+                    docker save di-benchmark-${{ matrix.container }} -o di-benchmark-${{ matrix.container }}.tar
             - name: Upload image
-              uses: actions/upload-artifact@v4
-              with:
-                  name: di-benchmark-${{ matrix.container }}
-                  path: di-benchmark-${{ matrix.container }}.tar
-
+                uses: actions/upload-artifact@v4
+                with:
+                    name: di-benchmark-${{ matrix.container }}
+                    path: di-benchmark-${{ matrix.container }}.tar
     benchmark-fast-06:
         if: github.actor != 'github-actions[bot]'
         needs: build-fast
@@ -121,26 +114,33 @@ jobs:
                     - f06_startup
                 run:
                     - 1
+                    - 2
+                    - 3
+                    - 4
+                    - 5
+                    - 6
+                    - 7
+                    - 8
+                    - 9
+                    - 10
         steps:
             - uses: actions/checkout@v5
             - name: Download image
-              uses: actions/download-artifact@v5
-              with:
-                  name: di-benchmark-${{ matrix.container }}
-                  path: .
+                uses: actions/download-artifact@v5
+                with:
+                    name: di-benchmark-${{ matrix.container }}
+                    path: .
             - name: Load image
-              run: docker load -i di-benchmark-${{ matrix.container }}.tar
+                run: docker load -i di-benchmark-${{ matrix.container }}.tar
             - name: Run benchmarks
-              run: |
-                  docker run --rm -v "$PWD:/out" di-benchmark-${{ matrix.container }} \
-                      php benchmark.php ${{ matrix.test }} 10 2>&1
-                  mv results.json ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
+                run: |
+                    docker run --rm -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 1 2>&1
+                    mv results.json ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
             - name: Upload results
-              uses: actions/upload-artifact@v4
-              with:
-                  name: result-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}
-                  path: ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
-
+                uses: actions/upload-artifact@v4
+                with:
+                    name: result-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}
+                    path: ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
     benchmark-fast-16:
         if: github.actor != 'github-actions[bot]'
         needs: build-fast
@@ -165,23 +165,21 @@ jobs:
         steps:
             - uses: actions/checkout@v5
             - name: Download image
-              uses: actions/download-artifact@v5
-              with:
-                  name: di-benchmark-${{ matrix.container }}
-                  path: .
+                uses: actions/download-artifact@v5
+                with:
+                    name: di-benchmark-${{ matrix.container }}
+                    path: .
             - name: Load image
-              run: docker load -i di-benchmark-${{ matrix.container }}.tar
+                run: docker load -i di-benchmark-${{ matrix.container }}.tar
             - name: Run benchmarks
-              run: |
-                  docker run --rm -v "$PWD:/out" di-benchmark-${{ matrix.container }} \
-                      php benchmark.php ${{ matrix.test }} 10 2>&1
-                  mv results.json ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
+                run: |
+                    docker run --rm -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 10 2>&1
+                    mv results.json ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
             - name: Upload results
-              uses: actions/upload-artifact@v4
-              with:
-                  name: result-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}
-                  path: ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
-
+                uses: actions/upload-artifact@v4
+                with:
+                    name: result-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}
+                    path: ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
     benchmark-fast-26:
         if: github.actor != 'github-actions[bot]'
         needs: build-fast
@@ -206,23 +204,21 @@ jobs:
         steps:
             - uses: actions/checkout@v5
             - name: Download image
-              uses: actions/download-artifact@v5
-              with:
-                  name: di-benchmark-${{ matrix.container }}
-                  path: .
+                uses: actions/download-artifact@v5
+                with:
+                    name: di-benchmark-${{ matrix.container }}
+                    path: .
             - name: Load image
-              run: docker load -i di-benchmark-${{ matrix.container }}.tar
+                run: docker load -i di-benchmark-${{ matrix.container }}.tar
             - name: Run benchmarks
-              run: |
-                  docker run --rm -v "$PWD:/out" di-benchmark-${{ matrix.container }} \
-                      php benchmark.php ${{ matrix.test }} 10 2>&1
-                  mv results.json ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
+                run: |
+                    docker run --rm -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 10 2>&1
+                    mv results.json ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
             - name: Upload results
-              uses: actions/upload-artifact@v4
-              with:
-                  name: result-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}
-                  path: ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
-
+                uses: actions/upload-artifact@v4
+                with:
+                    name: result-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}
+                    path: ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
     benchmark-fast-in-06:
         if: github.actor != 'github-actions[bot]'
         needs: build-fast
@@ -247,23 +243,21 @@ jobs:
         steps:
             - uses: actions/checkout@v5
             - name: Download image
-              uses: actions/download-artifact@v5
-              with:
-                  name: di-benchmark-${{ matrix.container }}
-                  path: .
+                uses: actions/download-artifact@v5
+                with:
+                    name: di-benchmark-${{ matrix.container }}
+                    path: .
             - name: Load image
-              run: docker load -i di-benchmark-${{ matrix.container }}.tar
+                run: docker load -i di-benchmark-${{ matrix.container }}.tar
             - name: Run benchmarks
-              run: |
-                  docker run --rm -v "$PWD:/out" di-benchmark-${{ matrix.container }} \\
-                      php benchmark.php ${{ matrix.test }} 10 2>&1
-                  mv results.json ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
+                run: |
+                    docker run --rm -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 10 2>&1
+                    mv results.json ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
             - name: Upload results
-              uses: actions/upload-artifact@v4
-              with:
-                  name: result-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}
-                  path: ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
-
+                uses: actions/upload-artifact@v4
+                with:
+                    name: result-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}
+                    path: ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
     benchmark-fast-in-16:
         if: github.actor != 'github-actions[bot]'
         needs: build-fast
@@ -288,23 +282,21 @@ jobs:
         steps:
             - uses: actions/checkout@v5
             - name: Download image
-              uses: actions/download-artifact@v5
-              with:
-                  name: di-benchmark-${{ matrix.container }}
-                  path: .
+                uses: actions/download-artifact@v5
+                with:
+                    name: di-benchmark-${{ matrix.container }}
+                    path: .
             - name: Load image
-              run: docker load -i di-benchmark-${{ matrix.container }}.tar
+                run: docker load -i di-benchmark-${{ matrix.container }}.tar
             - name: Run benchmarks
-              run: |
-                  docker run --rm -v "$PWD:/out" di-benchmark-${{ matrix.container }} \\
-                      php benchmark.php ${{ matrix.test }} 10 2>&1
-                  mv results.json ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
+                run: |
+                    docker run --rm -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 10 2>&1
+                    mv results.json ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
             - name: Upload results
-              uses: actions/upload-artifact@v4
-              with:
-                  name: result-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}
-                  path: ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
-
+                uses: actions/upload-artifact@v4
+                with:
+                    name: result-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}
+                    path: ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
     benchmark-fast-in-26:
         if: github.actor != 'github-actions[bot]'
         needs: build-fast
@@ -329,23 +321,21 @@ jobs:
         steps:
             - uses: actions/checkout@v5
             - name: Download image
-              uses: actions/download-artifact@v5
-              with:
-                  name: di-benchmark-${{ matrix.container }}
-                  path: .
+                uses: actions/download-artifact@v5
+                with:
+                    name: di-benchmark-${{ matrix.container }}
+                    path: .
             - name: Load image
-              run: docker load -i di-benchmark-${{ matrix.container }}.tar
+                run: docker load -i di-benchmark-${{ matrix.container }}.tar
             - name: Run benchmarks
-              run: |
-                  docker run --rm -v "$PWD:/out" di-benchmark-${{ matrix.container }} \\
-                      php benchmark.php ${{ matrix.test }} 10 2>&1
-                  mv results.json ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
+                run: |
+                    docker run --rm -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 10 2>&1
+                    mv results.json ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
             - name: Upload results
-              uses: actions/upload-artifact@v4
-              with:
-                  name: result-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}
-                  path: ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
-
+                uses: actions/upload-artifact@v4
+                with:
+                    name: result-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}
+                    path: ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
     benchmark-medium-06:
         if: github.actor != 'github-actions[bot]'
         needs:
@@ -372,23 +362,21 @@ jobs:
         steps:
             - uses: actions/checkout@v5
             - name: Download image
-              uses: actions/download-artifact@v5
-              with:
-                  name: di-benchmark-${{ matrix.container }}
-                  path: .
+                uses: actions/download-artifact@v5
+                with:
+                    name: di-benchmark-${{ matrix.container }}
+                    path: .
             - name: Load image
-              run: docker load -i di-benchmark-${{ matrix.container }}.tar
+                run: docker load -i di-benchmark-${{ matrix.container }}.tar
             - name: Run benchmarks
-              run: |
-                  docker run --rm -v "$PWD:/out" di-benchmark-${{ matrix.container }} \
-                      php benchmark.php ${{ matrix.test }} 5 2>&1
-                  mv results.json ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
+                run: |
+                    docker run --rm -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 5 2>&1
+                    mv results.json ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
             - name: Upload results
-              uses: actions/upload-artifact@v4
-              with:
-                  name: result-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}
-                  path: ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
-
+                uses: actions/upload-artifact@v4
+                with:
+                    name: result-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}
+                    path: ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
     benchmark-medium-16:
         if: github.actor != 'github-actions[bot]'
         needs:
@@ -423,22 +411,21 @@ jobs:
         steps:
             - uses: actions/checkout@v5
             - name: Download image
-              uses: actions/download-artifact@v5
-              with:
-                  name: di-benchmark-${{ matrix.container }}
-                  path: .
+                uses: actions/download-artifact@v5
+                with:
+                    name: di-benchmark-${{ matrix.container }}
+                    path: .
             - name: Load image
-              run: docker load -i di-benchmark-${{ matrix.container }}.tar
+                run: docker load -i di-benchmark-${{ matrix.container }}.tar
             - name: Run benchmarks
-              run: |
-                  docker run --rm -v "$PWD:/out" di-benchmark-${{ matrix.container }} \
-                      php benchmark.php ${{ matrix.test }} 1 2>&1
-                  mv results.json ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
+                run: |
+                    docker run --rm -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 1 2>&1
+                    mv results.json ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
             - name: Upload results
-              uses: actions/upload-artifact@v4
-              with:
-                  name: result-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}
-                  path: ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
+                uses: actions/upload-artifact@v4
+                with:
+                    name: result-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}
+                    path: ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
     benchmark-medium-in-06:
         if: github.actor != 'github-actions[bot]'
         needs:
@@ -465,23 +452,21 @@ jobs:
         steps:
             - uses: actions/checkout@v5
             - name: Download image
-              uses: actions/download-artifact@v5
-              with:
-                  name: di-benchmark-${{ matrix.container }}
-                  path: .
+                uses: actions/download-artifact@v5
+                with:
+                    name: di-benchmark-${{ matrix.container }}
+                    path: .
             - name: Load image
-              run: docker load -i di-benchmark-${{ matrix.container }}.tar
+                run: docker load -i di-benchmark-${{ matrix.container }}.tar
             - name: Run benchmarks
-              run: |
-                  docker run --rm -v "$PWD:/out" di-benchmark-${{ matrix.container }} \\
-                      php benchmark.php ${{ matrix.test }} 5 2>&1
-                  mv results.json ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
+                run: |
+                    docker run --rm -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 5 2>&1
+                    mv results.json ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
             - name: Upload results
-              uses: actions/upload-artifact@v4
-              with:
-                  name: result-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}
-                  path: ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
-
+                uses: actions/upload-artifact@v4
+                with:
+                    name: result-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}
+                    path: ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
     benchmark-medium-in-16:
         if: github.actor != 'github-actions[bot]'
         needs:
@@ -516,23 +501,21 @@ jobs:
         steps:
             - uses: actions/checkout@v5
             - name: Download image
-              uses: actions/download-artifact@v5
-              with:
-                  name: di-benchmark-${{ matrix.container }}
-                  path: .
+                uses: actions/download-artifact@v5
+                with:
+                    name: di-benchmark-${{ matrix.container }}
+                    path: .
             - name: Load image
-              run: docker load -i di-benchmark-${{ matrix.container }}.tar
+                run: docker load -i di-benchmark-${{ matrix.container }}.tar
             - name: Run benchmarks
-              run: |
-                  docker run --rm -v "$PWD:/out" di-benchmark-${{ matrix.container }} \\
-                      php benchmark.php ${{ matrix.test }} 1 2>&1
-                  mv results.json ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
+                run: |
+                    docker run --rm -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 1 2>&1
+                    mv results.json ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
             - name: Upload results
-              uses: actions/upload-artifact@v4
-              with:
-                  name: result-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}
-                  path: ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
-
+                uses: actions/upload-artifact@v4
+                with:
+                    name: result-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}
+                    path: ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
     benchmark-slow-06:
         if: github.actor != 'github-actions[bot]'
         needs:
@@ -566,23 +549,21 @@ jobs:
         steps:
             - uses: actions/checkout@v5
             - name: Download image
-              uses: actions/download-artifact@v5
-              with:
-                  name: di-benchmark-${{ matrix.container }}
-                  path: .
+                uses: actions/download-artifact@v5
+                with:
+                    name: di-benchmark-${{ matrix.container }}
+                    path: .
             - name: Load image
-              run: docker load -i di-benchmark-${{ matrix.container }}.tar
+                run: docker load -i di-benchmark-${{ matrix.container }}.tar
             - name: Run benchmarks
-              run: |
-                  docker run --rm -v "$PWD:/out" di-benchmark-${{ matrix.container }} \
-                      php benchmark.php ${{ matrix.test }} 1 2>&1
-                  mv results.json ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
+                run: |
+                    docker run --rm -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 1 2>&1
+                    mv results.json ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
             - name: Upload results
-              uses: actions/upload-artifact@v4
-              with:
-                  name: result-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}
-                  path: ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
-
+                uses: actions/upload-artifact@v4
+                with:
+                    name: result-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}
+                    path: ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
     benchmark-slow-in-06:
         if: github.actor != 'github-actions[bot]'
         needs:
@@ -616,23 +597,21 @@ jobs:
         steps:
             - uses: actions/checkout@v5
             - name: Download image
-              uses: actions/download-artifact@v5
-              with:
-                  name: di-benchmark-${{ matrix.container }}
-                  path: .
+                uses: actions/download-artifact@v5
+                with:
+                    name: di-benchmark-${{ matrix.container }}
+                    path: .
             - name: Load image
-              run: docker load -i di-benchmark-${{ matrix.container }}.tar
+                run: docker load -i di-benchmark-${{ matrix.container }}.tar
             - name: Run benchmarks
-              run: |
-                  docker run --rm -v "$PWD:/out" di-benchmark-${{ matrix.container }} \\
-                      php benchmark.php ${{ matrix.test }} 1 2>&1
-                  mv results.json ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
+                run: |
+                    docker run --rm -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 1 2>&1
+                    mv results.json ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
             - name: Upload results
-              uses: actions/upload-artifact@v4
-              with:
-                  name: result-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}
-                  path: ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
-
+                uses: actions/upload-artifact@v4
+                with:
+                    name: result-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}
+                    path: ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
     aggregate:
         if: github.actor != 'github-actions[bot]'
         needs:
@@ -664,8 +643,7 @@ jobs:
             - name: Commit results
               run: |
                   git config --global user.name 'github-actions[bot]'
-                  git config --global user.email \
-                      'github-actions[bot]@users.noreply.github.com'
+                  git config --global user.email 'github-actions[bot]@users.noreply.github.com'
                   git add README.md images/speed_comparison_*.jpg run_summary.yaml proposed-workflow.yml
                   if [ "$GITHUB_EVENT_NAME" = "schedule" ]; then
                       git add archive

--- a/tools/update_workflow.php
+++ b/tools/update_workflow.php
@@ -32,15 +32,176 @@ function parse_run_summary(string $filename): array {
     return [$containers, $values];
 }
 
-function replace_container_list(string $workflow, string $job, array $containers): string {
-    $pattern = '/(^    ' . preg_quote($job, '/') . ":\n[\s\S]*?container:\n)(?: {20}- .*?\n| {20}\[\]\n)+/m";
-    if ($containers === []) {
-        $replacement = "$1                    []\n";
-    } else {
-        $replacement = "$1" . implode('', array_map(fn($c) => "                    - $c\n", $containers));
-    }
-    return preg_replace($pattern, $replacement, $workflow);
+function indent(int $level): string {
+    return str_repeat(' ', $level * 4);
 }
+
+function format_list(array $items, int $level): string {
+    if ($items === []) {
+        return indent($level) . "[]\n";
+    }
+    return implode('', array_map(fn($i) => indent($level) . "- $i\n", $items));
+}
+
+function build_job(string $name, array $containers): string {
+    $yaml  = indent(1) . "$name:\n";
+    $yaml .= indent(2) . "if: github.actor != 'github-actions[bot]'\n";
+    $yaml .= indent(2) . "runs-on: ubuntu-latest\n";
+    $yaml .= indent(2) . "strategy:\n";
+    $yaml .= indent(3) . "matrix:\n";
+    $yaml .= indent(4) . "container:\n";
+    $yaml .= format_list($containers, 5);
+    $yaml .= indent(2) . "steps:\n";
+    $yaml .= indent(3) . "- uses: actions/checkout@v5\n";
+    $yaml .= indent(3) . "- name: Build container\n";
+    $yaml .= indent(4) . "run: |\n";
+    $yaml .= indent(5) . 'docker build -t di-benchmark-${{ matrix.container }} -f containers/${{ matrix.container }}/Dockerfile .' . "\n";
+    $yaml .= indent(5) . 'docker save di-benchmark-${{ matrix.container }} -o di-benchmark-${{ matrix.container }}.tar' . "\n";
+    $yaml .= indent(3) . "- name: Upload image\n";
+    $yaml .= indent(4) . "uses: actions/upload-artifact@v4\n";
+    $yaml .= indent(4) . "with:\n";
+    $yaml .= indent(5) . 'name: di-benchmark-${{ matrix.container }}' . "\n";
+    $yaml .= indent(5) . 'path: di-benchmark-${{ matrix.container }}.tar' . "\n";
+    return $yaml;
+}
+
+function benchmark_job(string $name, array $needs, array $containers, array $tests, array $runs, int $iterations): string {
+    $yaml  = indent(1) . "$name:\n";
+    $yaml .= indent(2) . "if: github.actor != 'github-actions[bot]'\n";
+    if (count($needs) === 1) {
+        $yaml .= indent(2) . 'needs: ' . $needs[0] . "\n";
+    } else {
+        $yaml .= indent(2) . "needs:\n";
+        $yaml .= format_list($needs, 3);
+    }
+    $yaml .= indent(2) . "runs-on: ubuntu-latest\n";
+    $yaml .= indent(2) . "strategy:\n";
+    $yaml .= indent(3) . "matrix:\n";
+    $yaml .= indent(4) . "container:\n";
+    $yaml .= format_list($containers, 5);
+    $yaml .= indent(4) . "test:\n";
+    $yaml .= format_list($tests, 5);
+    $yaml .= indent(4) . "run:\n";
+    $yaml .= format_list($runs, 5);
+    $yaml .= indent(2) . "steps:\n";
+    $yaml .= indent(3) . "- uses: actions/checkout@v5\n";
+    $yaml .= indent(3) . "- name: Download image\n";
+    $yaml .= indent(4) . "uses: actions/download-artifact@v5\n";
+    $yaml .= indent(4) . "with:\n";
+    $yaml .= indent(5) . 'name: di-benchmark-${{ matrix.container }}' . "\n";
+    $yaml .= indent(5) . "path: .\n";
+    $yaml .= indent(3) . "- name: Load image\n";
+    $yaml .= indent(4) . 'run: docker load -i di-benchmark-${{ matrix.container }}.tar' . "\n";
+    $yaml .= indent(3) . "- name: Run benchmarks\n";
+    $yaml .= indent(4) . "run: |\n";
+    $yaml .= indent(5) . 'docker run --rm -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} ' . $iterations . " 2>&1\n";
+    $yaml .= indent(5) . 'mv results.json ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json' . "\n";
+    $yaml .= indent(3) . "- name: Upload results\n";
+    $yaml .= indent(4) . "uses: actions/upload-artifact@v4\n";
+    $yaml .= indent(4) . "with:\n";
+    $yaml .= indent(5) . 'name: result-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}' . "\n";
+    $yaml .= indent(5) . 'path: ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json' . "\n";
+    return $yaml;
+}
+
+function aggregate_job(): string {
+    return <<<'YAML'
+    aggregate:
+        if: github.actor != 'github-actions[bot]'
+        needs:
+            - benchmark-fast-26
+            - benchmark-fast-in-26
+            - benchmark-medium-16
+            - benchmark-medium-in-16
+            - benchmark-slow-06
+            - benchmark-slow-in-06
+        permissions: write-all
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v5
+            - name: Download results
+              uses: actions/download-artifact@v5
+              with:
+                  pattern: 'result-*-*-*'
+                  merge-multiple: true
+            - name: Merge test results
+              run: php tools/merge_json.php
+            - name: Generate graphs
+              run: php tools/generate_graphs.php
+            - name: Generate run summary
+              run: php tools/generate_run_summary.php
+            - name: Generate README
+              run: php tools/generate_readme.php
+            - name: Update workflow
+              run: php tools/update_workflow.php
+            - name: Commit results
+              run: |
+                  git config --global user.name 'github-actions[bot]'
+                  git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+                  git add README.md images/speed_comparison_*.jpg run_summary.yaml proposed-workflow.yml
+                  if [ "$GITHUB_EVENT_NAME" = "schedule" ]; then
+                      git add archive
+                  fi
+                  git commit -m "Update test results" || echo "No changes to commit"
+                  git push
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+YAML;
+}
+
+function build_workflow(array $fast, array $medium, array $slow): string {
+    $header = <<<'YAML'
+---
+name: Update test results
+
+'on':
+    workflow_dispatch:
+    schedule:
+        - cron: '0 0 1 * *'
+    push:
+        branches:
+            - the-one
+        paths:
+            - '**/*.php'
+            - '**/*.json'
+            - '.github/workflows/update-test-results.yml'
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
+jobs:
+
+YAML;
+
+    $yaml = $header;
+    $yaml .= build_job('build-fast', $fast);
+    $yaml .= build_job('build-medium', $medium);
+    $yaml .= build_job('build-slow', $slow);
+
+    $benchmarks = [
+        ['benchmark-fast-06', ['build-fast'], $fast, ['f06', 'f06_startup'], range(1, 10), 1],
+        ['benchmark-fast-16', ['build-fast'], $fast, ['p16', 'p16_startup'], [1], 10],
+        ['benchmark-fast-26', ['build-fast'], $fast, ['z26', 'z26_startup'], [1], 10],
+        ['benchmark-fast-in-06', ['build-fast'], $fast, ['fin06', 'fin06_startup'], [1], 10],
+        ['benchmark-fast-in-16', ['build-fast'], $fast, ['pin16', 'pin16_startup'], [1], 10],
+        ['benchmark-fast-in-26', ['build-fast'], $fast, ['zin26', 'zin26_startup'], [1], 10],
+        ['benchmark-medium-06', ['build-medium', 'benchmark-fast-06'], $medium, ['f06', 'f06_startup'], [1, 2], 5],
+        ['benchmark-medium-16', ['benchmark-fast-16', 'build-medium'], $medium, ['p16', 'p16_startup'], range(1, 10), 1],
+        ['benchmark-medium-in-06', ['build-medium', 'benchmark-fast-in-06'], $medium, ['fin06', 'fin06_startup'], [1, 2], 5],
+        ['benchmark-medium-in-16', ['benchmark-fast-in-16', 'build-medium'], $medium, ['pin16', 'pin16_startup'], range(1, 10), 1],
+        ['benchmark-slow-06', ['benchmark-medium-06', 'build-slow'], $slow, ['f06', 'f06_startup'], range(1, 10), 1],
+        ['benchmark-slow-in-06', ['benchmark-medium-in-06', 'build-slow'], $slow, ['fin06', 'fin06_startup'], range(1, 10), 1],
+    ];
+
+    foreach ($benchmarks as [$name, $needs, $containers, $tests, $runs, $iterations]) {
+        $yaml .= benchmark_job($name, $needs, $containers, $tests, $runs, $iterations);
+    }
+
+    $yaml .= aggregate_job();
+    return $yaml;
+}
+
 
 [$containers, $summary] = parse_run_summary('run_summary.yaml');
 
@@ -87,25 +248,5 @@ foreach ($containers as $container) {
     }
 }
 
-$workflowFile = '.github/workflows/update-test-results.yml';
-$workflow = file_get_contents($workflowFile);
-
-$workflow = replace_container_list($workflow, 'build-fast', $fast);
-$workflow = replace_container_list($workflow, 'benchmark-fast-06', $fast);
-$workflow = replace_container_list($workflow, 'benchmark-fast-16', $fast);
-$workflow = replace_container_list($workflow, 'benchmark-fast-26', $fast);
-$workflow = replace_container_list($workflow, 'benchmark-fast-in-06', $fast);
-$workflow = replace_container_list($workflow, 'benchmark-fast-in-16', $fast);
-$workflow = replace_container_list($workflow, 'benchmark-fast-in-26', $fast);
-
-$workflow = replace_container_list($workflow, 'build-medium', $medium);
-$workflow = replace_container_list($workflow, 'benchmark-medium-06', $medium);
-$workflow = replace_container_list($workflow, 'benchmark-medium-16', $medium);
-$workflow = replace_container_list($workflow, 'benchmark-medium-in-06', $medium);
-$workflow = replace_container_list($workflow, 'benchmark-medium-in-16', $medium);
-
-$workflow = replace_container_list($workflow, 'build-slow', $slow);
-$workflow = replace_container_list($workflow, 'benchmark-slow-06', $slow);
-$workflow = replace_container_list($workflow, 'benchmark-slow-in-06', $slow);
-
+$workflow = build_workflow($fast, $medium, $slow);
 file_put_contents('proposed-workflow.yml', $workflow);


### PR DESCRIPTION
## Summary
- Build GitHub Actions workflow YAML entirely from PHP using helper functions
- Remove patch-based updates and write freshly generated workflow to `proposed-workflow.yml`

## Testing
- `php -l tools/update_workflow.php`


------
https://chatgpt.com/codex/tasks/task_e_68c0f3ebc3cc832fbbcd50cf024c7330

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI**
  * Workflow is now auto-generated from benchmark data, producing a unified proposed workflow with an aggregate job.
  * Normalized command and artifact step formatting for readability; no behavior change.

* **Benchmarking**
  * Adjusted iteration counts and some test matrices (fewer runs, occasionally excluding the first case) to speed up feedback while keeping coverage.

* **Chores**
  * Minor commit configuration and end-of-file formatting cleanups.

* **Refactor**
  * Replaced patch-based workflow edits with a data-driven build process for more predictable, maintainable pipeline generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->