### PR TITLE
Filter interface tests to configured and compiled containers

### DIFF
--- a/proposed-workflow.yml
+++ b/proposed-workflow.yml
@@ -226,13 +226,10 @@ jobs:
         strategy:
             matrix:
                 container:
-                    - laminas-servicemanager.reflection.singleton
                     - nette-di.compiled.singleton
-                    - php-di.reflection.singleton
                     - pimple.configured.singleton
                     - quickly.compiled.singleton
                     - quickly.configured.singleton
-                    - quickly.reflection.singleton
                     - symfony.compiled.singleton
                     - zen.compiled.singleton
                 test:
@@ -265,13 +262,10 @@ jobs:
         strategy:
             matrix:
                 container:
-                    - laminas-servicemanager.reflection.singleton
                     - nette-di.compiled.singleton
-                    - php-di.reflection.singleton
                     - pimple.configured.singleton
                     - quickly.compiled.singleton
                     - quickly.configured.singleton
-                    - quickly.reflection.singleton
                     - symfony.compiled.singleton
                     - zen.compiled.singleton
                 test:
@@ -304,13 +298,10 @@ jobs:
         strategy:
             matrix:
                 container:
-                    - laminas-servicemanager.reflection.singleton
                     - nette-di.compiled.singleton
-                    - php-di.reflection.singleton
                     - pimple.configured.singleton
                     - quickly.compiled.singleton
                     - quickly.configured.singleton
-                    - quickly.reflection.singleton
                     - symfony.compiled.singleton
                     - zen.compiled.singleton
                 test:
@@ -437,11 +428,7 @@ jobs:
                 container:
                     - aura-di.configured.transient
                     - dice.configured.singleton
-                    - dice.reflection.transient
-                    - laravel.reflection.singleton
-                    - laravel.reflection.transient
                     - phalcon.configured.singleton
-                    - php-baseline
                     - pimple.configured.transient
                 test:
                     - fin06
@@ -478,11 +465,7 @@ jobs:
                 container:
                     - aura-di.configured.transient
                     - dice.configured.singleton
-                    - dice.reflection.transient
-                    - laravel.reflection.singleton
-                    - laravel.reflection.transient
                     - phalcon.configured.singleton
-                    - php-baseline
                     - pimple.configured.transient
                 test:
                     - pin16
@@ -573,13 +556,10 @@ jobs:
         strategy:
             matrix:
                 container:
-                    - auryn.reflection.transient
                     - laravel.configured.transient
                     - league.configured.transient
-                    - league.reflection.transient
                     - phalcon.configured.transient
                     - ray-di.compiled.transient
-                    - ray-di.reflection.transient
                 test:
                     - fin06
                     - fin06_startup

--- a/tools/update_workflow.php
+++ b/tools/update_workflow.php
@@ -180,19 +180,23 @@ YAML;
     $yaml .= build_job('build-medium', $medium);
     $yaml .= build_job('build-slow', $slow);
 
+    $fastInterfaces = array_values(array_filter($fast, fn($c) => str_contains($c, '.configured.') || str_contains($c, '.compiled.')));
+    $mediumInterfaces = array_values(array_filter($medium, fn($c) => str_contains($c, '.configured.') || str_contains($c, '.compiled.')));
+    $slowInterfaces = array_values(array_filter($slow, fn($c) => str_contains($c, '.configured.') || str_contains($c, '.compiled.')));
+
     $benchmarks = [
         ['benchmark-fast-06', ['build-fast'], $fast, ['f06', 'f06_startup'], range(1, 10), 1],
         ['benchmark-fast-16', ['build-fast'], $fast, ['p16', 'p16_startup'], [1], 10],
         ['benchmark-fast-26', ['build-fast'], $fast, ['z26', 'z26_startup'], [1], 10],
-        ['benchmark-fast-in-06', ['build-fast'], $fast, ['fin06', 'fin06_startup'], [1], 10],
-        ['benchmark-fast-in-16', ['build-fast'], $fast, ['pin16', 'pin16_startup'], [1], 10],
-        ['benchmark-fast-in-26', ['build-fast'], $fast, ['zin26', 'zin26_startup'], [1], 10],
+        ['benchmark-fast-in-06', ['build-fast'], $fastInterfaces, ['fin06', 'fin06_startup'], [1], 10],
+        ['benchmark-fast-in-16', ['build-fast'], $fastInterfaces, ['pin16', 'pin16_startup'], [1], 10],
+        ['benchmark-fast-in-26', ['build-fast'], $fastInterfaces, ['zin26', 'zin26_startup'], [1], 10],
         ['benchmark-medium-06', ['build-medium', 'benchmark-fast-06'], $medium, ['f06', 'f06_startup'], [1, 2], 5],
         ['benchmark-medium-16', ['benchmark-fast-16', 'build-medium'], $medium, ['p16', 'p16_startup'], range(1, 10), 1],
-        ['benchmark-medium-in-06', ['build-medium', 'benchmark-fast-in-06'], $medium, ['fin06', 'fin06_startup'], [1, 2], 5],
-        ['benchmark-medium-in-16', ['benchmark-fast-in-16', 'build-medium'], $medium, ['pin16', 'pin16_startup'], range(1, 10), 1],
+        ['benchmark-medium-in-06', ['build-medium', 'benchmark-fast-in-06'], $mediumInterfaces, ['fin06', 'fin06_startup'], [1, 2], 5],
+        ['benchmark-medium-in-16', ['benchmark-fast-in-16', 'build-medium'], $mediumInterfaces, ['pin16', 'pin16_startup'], range(1, 10), 1],
         ['benchmark-slow-06', ['benchmark-medium-06', 'build-slow'], $slow, ['f06', 'f06_startup'], range(1, 10), 1],
-        ['benchmark-slow-in-06', ['benchmark-medium-in-06', 'build-slow'], $slow, ['fin06', 'fin06_startup'], range(1, 10), 1],
+        ['benchmark-slow-in-06', ['benchmark-medium-in-06', 'build-slow'], $slowInterfaces, ['fin06', 'fin06_startup'], range(1, 10), 1],
     ];
 
     foreach ($benchmarks as [$name, $needs, $containers, $tests, $runs, $iterations]) {


### PR DESCRIPTION
## Summary
- exclude reflection-based containers from interface benchmarks
- regenerate workflow to run interface tests only on configured or compiled containers

## Testing
- `php -l tools/update_workflow.php`
- `php tools/update_workflow.php`


------
https://chatgpt.com/codex/tasks/task_e_68c1538aaee4832fac7e2ab50056c1e5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined CI by pruning several reflection-based and baseline container variants across fast, medium, and slow build/benchmark matrices, reducing runtime.

* **Tests**
  * Updated benchmark configurations: “-in” suites now target interface-ready containers, while non “-in” suites remain unchanged.
  * Reduced matrix sizes in selected fast, medium, and slow runs to focus on relevant implementations and speed up feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->