### PR TITLE
Precompile Nette DI container during Docker build

### DIFF
--- a/containers/nette-di.compiled.singleton/AdapterImplementation.php
+++ b/containers/nette-di.compiled.singleton/AdapterImplementation.php
@@ -1,76 +1,16 @@
 <?php
 
-use Nette\DI\ContainerLoader;
-use Nette\DI\Compiler;
+require_once __DIR__ . '/CompiledContainer.php';
 
 class AdapterImplementation
 {
     private Nette\DI\Container $container;
+
     public function __construct()
     {
-        $loader = new ContainerLoader(sys_get_temp_dir(), true);
-        $class = $loader->load(function (Compiler $compiler) {
-            $definitions = [
-                F06::class => [E06::class, D06::class, B06::class],
-                E06::class => [D06::class, C06::class, B06::class],
-                D06::class => [C06::class, B06::class, A06::class],
-                C06::class => [B06::class],
-                B06::class => [A06::class],
-                A06::class => [],
-                P16::class => [O16::class, N16::class, M16::class],
-                O16::class => [N16::class, M16::class],
-                N16::class => [M16::class, L16::class, K16::class],
-                M16::class => [L16::class, K16::class],
-                L16::class => [K16::class],
-                K16::class => [J16::class, I16::class, H16::class],
-                J16::class => [I16::class, H16::class],
-                I16::class => [H16::class, G16::class, F16::class],
-                H16::class => [G16::class, F16::class],
-                G16::class => [F16::class],
-                F16::class => [E16::class, D16::class, B16::class],
-                E16::class => [D16::class, C16::class],
-                D16::class => [C16::class, B16::class, A16::class],
-                C16::class => [B16::class],
-                B16::class => [A16::class],
-                A16::class => [],
-                Z26::class => [Y26::class, X26::class, W26::class, V26::class, U26::class],
-                Y26::class => [X26::class, W26::class, V26::class, U26::class],
-                X26::class => [W26::class, V26::class, U26::class],
-                W26::class => [V26::class, U26::class],
-                V26::class => [U26::class],
-                U26::class => [T26::class, S26::class, R26::class, Q26::class, P26::class],
-                T26::class => [S26::class, R26::class, Q26::class, P26::class],
-                S26::class => [R26::class, Q26::class, P26::class],
-                R26::class => [Q26::class, P26::class],
-                Q26::class => [P26::class, O26::class, N26::class, M26::class, L26::class],
-                P26::class => [O26::class, N26::class, M26::class, L26::class],
-                O26::class => [N26::class, M26::class, L26::class],
-                N26::class => [M26::class, L26::class],
-                M26::class => [L26::class, K26::class, J26::class, I26::class, H26::class],
-                L26::class => [K26::class, J26::class, I26::class, H26::class, G26::class],
-                K26::class => [J26::class, I26::class, H26::class, G26::class, F26::class],
-                J26::class => [I26::class, H26::class, G26::class, F26::class],
-                I26::class => [H26::class, G26::class, F26::class],
-                H26::class => [G26::class, F26::class],
-                G26::class => [F26::class],
-                F26::class => [E26::class, D26::class, B26::class],
-                E26::class => [D26::class, C26::class],
-                D26::class => [C26::class, B26::class, A26::class],
-                C26::class => [B26::class],
-                B26::class => [A26::class],
-                A26::class => [],
-            ];
-            $services = [];
-            foreach ($definitions as $class => $deps) {
-                $services[] = $class;
-                $iface = substr($class, 0, 1) . 'In' . substr($class, 1);
-                $impl = substr($class, 0, 1) . 'Im' . substr($class, 1);
-                $services[$iface] = $impl;
-            }
-            $compiler->addConfig(['services' => $services]);
-        });
-        $this->container = new $class();
+        $this->container = new CompiledContainer();
     }
+
     public function get(string $class): object
     {
         return $this->container->getByType($class);

--- a/containers/nette-di.compiled.singleton/Dockerfile
+++ b/containers/nette-di.compiled.singleton/Dockerfile
@@ -9,4 +9,5 @@ RUN apt-get update \
     && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
     && composer install --no-interaction --no-progress
 COPY src/*.php ./
+RUN php compile.php
 CMD ["php", "benchmark.php"]

--- a/containers/nette-di.compiled.singleton/compile.php
+++ b/containers/nette-di.compiled.singleton/compile.php
@@ -1,0 +1,75 @@
+<?php
+
+require __DIR__ . '/vendor/autoload.php';
+require __DIR__ . '/classes-06.php';
+require __DIR__ . '/classes-16.php';
+require __DIR__ . '/classes-26.php';
+require __DIR__ . '/interfaces-06.php';
+require __DIR__ . '/interfaces-16.php';
+require __DIR__ . '/interfaces-26.php';
+
+$compiler = new Nette\DI\Compiler();
+$compiler->setClassName('CompiledContainer');
+
+$definitions = [
+    F06::class => [E06::class, D06::class, B06::class],
+    E06::class => [D06::class, C06::class, B06::class],
+    D06::class => [C06::class, B06::class, A06::class],
+    C06::class => [B06::class],
+    B06::class => [A06::class],
+    A06::class => [],
+    P16::class => [O16::class, N16::class, M16::class],
+    O16::class => [N16::class, M16::class],
+    N16::class => [M16::class, L16::class, K16::class],
+    M16::class => [L16::class, K16::class],
+    L16::class => [K16::class],
+    K16::class => [J16::class, I16::class, H16::class],
+    J16::class => [I16::class, H16::class],
+    I16::class => [H16::class, G16::class, F16::class],
+    H16::class => [G16::class, F16::class],
+    G16::class => [F16::class],
+    F16::class => [E16::class, D16::class, B16::class],
+    E16::class => [D16::class, C16::class],
+    D16::class => [C16::class, B16::class, A16::class],
+    C16::class => [B16::class],
+    B16::class => [A16::class],
+    A16::class => [],
+    Z26::class => [Y26::class, X26::class, W26::class, V26::class, U26::class],
+    Y26::class => [X26::class, W26::class, V26::class, U26::class],
+    X26::class => [W26::class, V26::class, U26::class],
+    W26::class => [V26::class, U26::class],
+    V26::class => [U26::class],
+    U26::class => [T26::class, S26::class, R26::class, Q26::class, P26::class],
+    T26::class => [S26::class, R26::class, Q26::class, P26::class],
+    S26::class => [R26::class, Q26::class, P26::class],
+    R26::class => [Q26::class, P26::class],
+    Q26::class => [P26::class, O26::class, N26::class, M26::class, L26::class],
+    P26::class => [O26::class, N26::class, M26::class, L26::class],
+    O26::class => [N26::class, M26::class, L26::class],
+    N26::class => [M26::class, L26::class],
+    M26::class => [L26::class, K26::class, J26::class, I26::class, H26::class],
+    L26::class => [K26::class, J26::class, I26::class, H26::class, G26::class],
+    K26::class => [J26::class, I26::class, H26::class, G26::class, F26::class],
+    J26::class => [I26::class, H26::class, G26::class, F26::class],
+    I26::class => [H26::class, G26::class, F26::class],
+    H26::class => [G26::class, F26::class],
+    G26::class => [F26::class],
+    F26::class => [E26::class, D26::class, B26::class],
+    E26::class => [D26::class, C26::class],
+    D26::class => [C26::class, B26::class, A26::class],
+    C26::class => [B26::class],
+    B26::class => [A26::class],
+    A26::class => [],
+];
+
+$services = [];
+foreach ($definitions as $class => $deps) {
+    $services[] = $class;
+    $iface = substr($class, 0, 1) . 'In' . substr($class, 1);
+    $impl = substr($class, 0, 1) . 'Im' . substr($class, 1);
+    $services[$iface] = $impl;
+}
+
+$compiler->addConfig(['services' => $services]);
+file_put_contents(__DIR__ . '/CompiledContainer.php', $compiler->compile());
+


### PR DESCRIPTION
## Summary
- Load a prebuilt Nette DI container instead of compiling at runtime.
- Add script to compile the Nette container during the image build.
- Invoke the compilation script from the container's Dockerfile.

## Testing
- `php -l containers/nette-di.compiled.singleton/AdapterImplementation.php`
- `php -l containers/nette-di.compiled.singleton/compile.php`


------
https://chatgpt.com/codex/tasks/task_e_68c1807ab52c832f913910e53cace6c9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Faster application startup and reduced runtime overhead by using a precompiled dependency injection container.
  * More consistent and predictable runtime behavior.

* **Refactor**
  * Migrated from dynamically generated containers to a precompiled approach with no user-facing API changes.

* **Chores**
  * Build process updated to compile the container during image creation for improved reliability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->