### PR TITLE
Fix Quickly configured singleton missing interface aliases

### DIFF
--- a/containers/quickly.configured.singleton/composer.json
+++ b/containers/quickly.configured.singleton/composer.json
@@ -6,7 +6,10 @@
         "classmap": [
             "classes-06.php",
             "classes-16.php",
-            "classes-26.php"
+            "classes-26.php",
+            "interfaces-06.php",
+            "interfaces-16.php",
+            "interfaces-26.php"
         ]
     }
 }


### PR DESCRIPTION
## Summary
- include interface definition files in Quickly configured singleton's classmap so aliases are generated

## Testing
- `composer dump-autoload`
- `vendor/bin/quickly build`
- `php benchmark.php zin26_startup 10`


------
https://chatgpt.com/codex/tasks/task_e_68c19250aa08832fa7770819bd43e085

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency configuration to improve component discovery during startup.
  * Enhances reliability when loading core interfaces, reducing rare initialization issues.
  * Minor improvements to load consistency that may slightly decrease startup hiccups in complex setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->