### PR TITLE
Cache PHP 8.4 CLI image for builds

### DIFF
--- a/.github/workflows/update-test-results.yml
+++ b/.github/workflows/update-test-results.yml
@@ -18,8 +18,21 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
+    download-php-cli:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Pull PHP CLI image
+              run: docker pull php:8.4-cli
+            - name: Save PHP CLI image
+              run: docker save php:8.4-cli -o php-8.4-cli.tar
+            - name: Upload PHP CLI image
+              uses: actions/upload-artifact@v4
+              with:
+                  name: php-8.4-cli
+                  path: php-8.4-cli.tar
     build-fast:
         if: github.actor != 'github-actions[bot]'
+        needs: download-php-cli
         runs-on: ubuntu-latest
         strategy:
             matrix:
@@ -35,6 +48,13 @@ jobs:
                     - zen.compiled.singleton
         steps:
             - uses: actions/checkout@v5
+            - name: Download PHP CLI image
+              uses: actions/download-artifact@v5
+              with:
+                  name: php-8.4-cli
+                  path: .
+            - name: Load PHP CLI image
+              run: docker load -i php-8.4-cli.tar
             - name: Build container
               run: |
                   docker build -t di-benchmark-${{ matrix.container }} -f containers/${{ matrix.container }}/Dockerfile .
@@ -46,6 +66,7 @@ jobs:
                   path: di-benchmark-${{ matrix.container }}.tar
     build-medium:
         if: github.actor != 'github-actions[bot]'
+        needs: download-php-cli
         runs-on: ubuntu-latest
         strategy:
             matrix:
@@ -60,6 +81,13 @@ jobs:
                     - pimple.configured.transient
         steps:
             - uses: actions/checkout@v5
+            - name: Download PHP CLI image
+              uses: actions/download-artifact@v5
+              with:
+                  name: php-8.4-cli
+                  path: .
+            - name: Load PHP CLI image
+              run: docker load -i php-8.4-cli.tar
             - name: Build container
               run: |
                   docker build -t di-benchmark-${{ matrix.container }} -f containers/${{ matrix.container }}/Dockerfile .
@@ -71,6 +99,7 @@ jobs:
                   path: di-benchmark-${{ matrix.container }}.tar
     build-slow:
         if: github.actor != 'github-actions[bot]'
+        needs: download-php-cli
         runs-on: ubuntu-latest
         strategy:
             matrix:
@@ -84,6 +113,13 @@ jobs:
                     - ray-di.reflection.transient
         steps:
             - uses: actions/checkout@v5
+            - name: Download PHP CLI image
+              uses: actions/download-artifact@v5
+              with:
+                  name: php-8.4-cli
+                  path: .
+            - name: Load PHP CLI image
+              run: docker load -i php-8.4-cli.tar
             - name: Build container
               run: |
                   docker build -t di-benchmark-${{ matrix.container }} -f containers/${{ matrix.container }}/Dockerfile .
@@ -597,29 +633,29 @@ jobs:
         steps:
             - uses: actions/checkout@v5
             - name: Download results
-              uses: actions/download-artifact@v5
-              with:
-                  pattern: 'result-*-*-*'
-                  merge-multiple: true
+                uses: actions/download-artifact@v5
+                with:
+                    pattern: 'result-*-*-*'
+                    merge-multiple: true
             - name: Merge test results
-              run: php tools/merge_json.php
+                run: php tools/merge_json.php
             - name: Generate graphs
-              run: php tools/generate_graphs.php
+                run: php tools/generate_graphs.php
             - name: Generate run summary
-              run: php tools/generate_run_summary.php
+                run: php tools/generate_run_summary.php
             - name: Generate README
-              run: php tools/generate_readme.php
+                run: php tools/generate_readme.php
             - name: Update workflow
-              run: php tools/update_workflow.php
+                run: php tools/update_workflow.php
             - name: Commit results
-              run: |
-                  git config --global user.name 'github-actions[bot]'
-                  git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-                  git add README.md images/speed_comparison_*.jpg run_summary.yaml proposed-workflow.yml
-                  if [ "$GITHUB_EVENT_NAME" = "schedule" ]; then
-                      git add archive
-                  fi
-                  git commit -m "Update test results" || echo "No changes to commit"
-                  git push
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                run: |
+                    git config --global user.name 'github-actions[bot]'
+                    git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+                    git add README.md images/speed_comparison_*.jpg run_summary.yaml proposed-workflow.yml
+                    if [ "$GITHUB_EVENT_NAME" = "schedule" ]; then
+                        git add archive
+                    fi
+                    git commit -m "Update test results" || echo "No changes to commit"
+                    git push
+                env:
+                    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-test-results.yml
+++ b/.github/workflows/update-test-results.yml
@@ -28,8 +28,8 @@ jobs:
             - name: Upload PHP CLI image
               uses: actions/upload-artifact@v4
               with:
-                  name: php-8.4-cli
-                  path: php-8.4-cli.tar
+                name: php-8.4-cli
+                path: php-8.4-cli.tar
     build-fast:
         if: github.actor != 'github-actions[bot]'
         needs: download-php-cli
@@ -51,8 +51,8 @@ jobs:
             - name: Download PHP CLI image
               uses: actions/download-artifact@v5
               with:
-                  name: php-8.4-cli
-                  path: .
+                name: php-8.4-cli
+                path: .
             - name: Load PHP CLI image
               run: docker load -i php-8.4-cli.tar
             - name: Build container
@@ -62,8 +62,8 @@ jobs:
             - name: Upload image
               uses: actions/upload-artifact@v4
               with:
-                  name: di-benchmark-${{ matrix.container }}
-                  path: di-benchmark-${{ matrix.container }}.tar
+                name: di-benchmark-${{ matrix.container }}
+                path: di-benchmark-${{ matrix.container }}.tar
     build-medium:
         if: github.actor != 'github-actions[bot]'
         needs: download-php-cli
@@ -84,8 +84,8 @@ jobs:
             - name: Download PHP CLI image
               uses: actions/download-artifact@v5
               with:
-                  name: php-8.4-cli
-                  path: .
+                name: php-8.4-cli
+                path: .
             - name: Load PHP CLI image
               run: docker load -i php-8.4-cli.tar
             - name: Build container
@@ -95,8 +95,8 @@ jobs:
             - name: Upload image
               uses: actions/upload-artifact@v4
               with:
-                  name: di-benchmark-${{ matrix.container }}
-                  path: di-benchmark-${{ matrix.container }}.tar
+                name: di-benchmark-${{ matrix.container }}
+                path: di-benchmark-${{ matrix.container }}.tar
     build-slow:
         if: github.actor != 'github-actions[bot]'
         needs: download-php-cli
@@ -116,8 +116,8 @@ jobs:
             - name: Download PHP CLI image
               uses: actions/download-artifact@v5
               with:
-                  name: php-8.4-cli
-                  path: .
+                name: php-8.4-cli
+                path: .
             - name: Load PHP CLI image
               run: docker load -i php-8.4-cli.tar
             - name: Build container
@@ -127,8 +127,8 @@ jobs:
             - name: Upload image
               uses: actions/upload-artifact@v4
               with:
-                  name: di-benchmark-${{ matrix.container }}
-                  path: di-benchmark-${{ matrix.container }}.tar
+                name: di-benchmark-${{ matrix.container }}
+                path: di-benchmark-${{ matrix.container }}.tar
     benchmark-fast-06:
         if: github.actor != 'github-actions[bot]'
         needs: build-fast
@@ -155,8 +155,8 @@ jobs:
             - name: Download image
               uses: actions/download-artifact@v5
               with:
-                  name: di-benchmark-${{ matrix.container }}
-                  path: .
+                name: di-benchmark-${{ matrix.container }}
+                path: .
             - name: Load image
               run: docker load -i di-benchmark-${{ matrix.container }}.tar
             - name: Run benchmarks
@@ -166,8 +166,8 @@ jobs:
             - name: Upload results
               uses: actions/upload-artifact@v4
               with:
-                  name: result-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}
-                  path: ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
+                name: result-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}
+                path: ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
     benchmark-fast-16:
         if: github.actor != 'github-actions[bot]'
         needs: build-fast
@@ -194,8 +194,8 @@ jobs:
             - name: Download image
               uses: actions/download-artifact@v5
               with:
-                  name: di-benchmark-${{ matrix.container }}
-                  path: .
+                name: di-benchmark-${{ matrix.container }}
+                path: .
             - name: Load image
               run: docker load -i di-benchmark-${{ matrix.container }}.tar
             - name: Run benchmarks
@@ -205,8 +205,8 @@ jobs:
             - name: Upload results
               uses: actions/upload-artifact@v4
               with:
-                  name: result-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}
-                  path: ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
+                name: result-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}
+                path: ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
     benchmark-fast-26:
         if: github.actor != 'github-actions[bot]'
         needs: build-fast
@@ -233,8 +233,8 @@ jobs:
             - name: Download image
               uses: actions/download-artifact@v5
               with:
-                  name: di-benchmark-${{ matrix.container }}
-                  path: .
+                name: di-benchmark-${{ matrix.container }}
+                path: .
             - name: Load image
               run: docker load -i di-benchmark-${{ matrix.container }}.tar
             - name: Run benchmarks
@@ -244,8 +244,8 @@ jobs:
             - name: Upload results
               uses: actions/upload-artifact@v4
               with:
-                  name: result-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}
-                  path: ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
+                name: result-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}
+                path: ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
     benchmark-fast-in-06:
         if: github.actor != 'github-actions[bot]'
         needs: build-fast
@@ -269,8 +269,8 @@ jobs:
             - name: Download image
               uses: actions/download-artifact@v5
               with:
-                  name: di-benchmark-${{ matrix.container }}
-                  path: .
+                name: di-benchmark-${{ matrix.container }}
+                path: .
             - name: Load image
               run: docker load -i di-benchmark-${{ matrix.container }}.tar
             - name: Run benchmarks
@@ -280,8 +280,8 @@ jobs:
             - name: Upload results
               uses: actions/upload-artifact@v4
               with:
-                  name: result-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}
-                  path: ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
+                name: result-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}
+                path: ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
     benchmark-fast-in-16:
         if: github.actor != 'github-actions[bot]'
         needs: build-fast
@@ -305,8 +305,8 @@ jobs:
             - name: Download image
               uses: actions/download-artifact@v5
               with:
-                  name: di-benchmark-${{ matrix.container }}
-                  path: .
+                name: di-benchmark-${{ matrix.container }}
+                path: .
             - name: Load image
               run: docker load -i di-benchmark-${{ matrix.container }}.tar
             - name: Run benchmarks
@@ -316,8 +316,8 @@ jobs:
             - name: Upload results
               uses: actions/upload-artifact@v4
               with:
-                  name: result-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}
-                  path: ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
+                name: result-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}
+                path: ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
     benchmark-fast-in-26:
         if: github.actor != 'github-actions[bot]'
         needs: build-fast
@@ -341,8 +341,8 @@ jobs:
             - name: Download image
               uses: actions/download-artifact@v5
               with:
-                  name: di-benchmark-${{ matrix.container }}
-                  path: .
+                name: di-benchmark-${{ matrix.container }}
+                path: .
             - name: Load image
               run: docker load -i di-benchmark-${{ matrix.container }}.tar
             - name: Run benchmarks
@@ -352,8 +352,8 @@ jobs:
             - name: Upload results
               uses: actions/upload-artifact@v4
               with:
-                  name: result-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}
-                  path: ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
+                name: result-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}
+                path: ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
     benchmark-medium-06:
         if: github.actor != 'github-actions[bot]'
         needs:
@@ -382,8 +382,8 @@ jobs:
             - name: Download image
               uses: actions/download-artifact@v5
               with:
-                  name: di-benchmark-${{ matrix.container }}
-                  path: .
+                name: di-benchmark-${{ matrix.container }}
+                path: .
             - name: Load image
               run: docker load -i di-benchmark-${{ matrix.container }}.tar
             - name: Run benchmarks
@@ -393,8 +393,8 @@ jobs:
             - name: Upload results
               uses: actions/upload-artifact@v4
               with:
-                  name: result-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}
-                  path: ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
+                name: result-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}
+                path: ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
     benchmark-medium-16:
         if: github.actor != 'github-actions[bot]'
         needs:
@@ -431,8 +431,8 @@ jobs:
             - name: Download image
               uses: actions/download-artifact@v5
               with:
-                  name: di-benchmark-${{ matrix.container }}
-                  path: .
+                name: di-benchmark-${{ matrix.container }}
+                path: .
             - name: Load image
               run: docker load -i di-benchmark-${{ matrix.container }}.tar
             - name: Run benchmarks
@@ -442,8 +442,8 @@ jobs:
             - name: Upload results
               uses: actions/upload-artifact@v4
               with:
-                  name: result-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}
-                  path: ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
+                name: result-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}
+                path: ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
     benchmark-medium-in-06:
         if: github.actor != 'github-actions[bot]'
         needs:
@@ -468,8 +468,8 @@ jobs:
             - name: Download image
               uses: actions/download-artifact@v5
               with:
-                  name: di-benchmark-${{ matrix.container }}
-                  path: .
+                name: di-benchmark-${{ matrix.container }}
+                path: .
             - name: Load image
               run: docker load -i di-benchmark-${{ matrix.container }}.tar
             - name: Run benchmarks
@@ -479,8 +479,8 @@ jobs:
             - name: Upload results
               uses: actions/upload-artifact@v4
               with:
-                  name: result-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}
-                  path: ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
+                name: result-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}
+                path: ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
     benchmark-medium-in-16:
         if: github.actor != 'github-actions[bot]'
         needs:
@@ -513,8 +513,8 @@ jobs:
             - name: Download image
               uses: actions/download-artifact@v5
               with:
-                  name: di-benchmark-${{ matrix.container }}
-                  path: .
+                name: di-benchmark-${{ matrix.container }}
+                path: .
             - name: Load image
               run: docker load -i di-benchmark-${{ matrix.container }}.tar
             - name: Run benchmarks
@@ -524,8 +524,8 @@ jobs:
             - name: Upload results
               uses: actions/upload-artifact@v4
               with:
-                  name: result-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}
-                  path: ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
+                name: result-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}
+                path: ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
     benchmark-slow-06:
         if: github.actor != 'github-actions[bot]'
         needs:
@@ -561,8 +561,8 @@ jobs:
             - name: Download image
               uses: actions/download-artifact@v5
               with:
-                  name: di-benchmark-${{ matrix.container }}
-                  path: .
+                name: di-benchmark-${{ matrix.container }}
+                path: .
             - name: Load image
               run: docker load -i di-benchmark-${{ matrix.container }}.tar
             - name: Run benchmarks
@@ -572,8 +572,8 @@ jobs:
             - name: Upload results
               uses: actions/upload-artifact@v4
               with:
-                  name: result-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}
-                  path: ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
+                name: result-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}
+                path: ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
     benchmark-slow-in-06:
         if: github.actor != 'github-actions[bot]'
         needs:
@@ -606,8 +606,8 @@ jobs:
             - name: Download image
               uses: actions/download-artifact@v5
               with:
-                  name: di-benchmark-${{ matrix.container }}
-                  path: .
+                name: di-benchmark-${{ matrix.container }}
+                path: .
             - name: Load image
               run: docker load -i di-benchmark-${{ matrix.container }}.tar
             - name: Run benchmarks
@@ -617,8 +617,8 @@ jobs:
             - name: Upload results
               uses: actions/upload-artifact@v4
               with:
-                  name: result-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}
-                  path: ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
+                name: result-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}
+                path: ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
     aggregate:
         if: github.actor != 'github-actions[bot]'
         needs:

--- a/proposed-workflow.yml
+++ b/proposed-workflow.yml
@@ -18,8 +18,21 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
+    download-php-cli:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Pull PHP CLI image
+              run: docker pull php:8.4-cli
+            - name: Save PHP CLI image
+              run: docker save php:8.4-cli -o php-8.4-cli.tar
+            - name: Upload PHP CLI image
+              uses: actions/upload-artifact@v4
+              with:
+                  name: php-8.4-cli
+                  path: php-8.4-cli.tar
     build-fast:
         if: github.actor != 'github-actions[bot]'
+        needs: download-php-cli
         runs-on: ubuntu-latest
         strategy:
             matrix:
@@ -35,10 +48,17 @@ jobs:
                     - zen.compiled.singleton
         steps:
             - uses: actions/checkout@v5
+            - name: Download PHP CLI image
+              uses: actions/download-artifact@v5
+              with:
+                  name: php-8.4-cli
+                  path: .
+            - name: Load PHP CLI image
+              run: docker load -i php-8.4-cli.tar
             - name: Build container
               run: |
-                    docker build -t di-benchmark-${{ matrix.container }} -f containers/${{ matrix.container }}/Dockerfile .
-                    docker save di-benchmark-${{ matrix.container }} -o di-benchmark-${{ matrix.container }}.tar
+                  docker build -t di-benchmark-${{ matrix.container }} -f containers/${{ matrix.container }}/Dockerfile .
+                  docker save di-benchmark-${{ matrix.container }} -o di-benchmark-${{ matrix.container }}.tar
             - name: Upload image
               uses: actions/upload-artifact@v4
               with:
@@ -46,6 +66,7 @@ jobs:
                   path: di-benchmark-${{ matrix.container }}.tar
     build-medium:
         if: github.actor != 'github-actions[bot]'
+        needs: download-php-cli
         runs-on: ubuntu-latest
         strategy:
             matrix:
@@ -60,10 +81,17 @@ jobs:
                     - pimple.configured.transient
         steps:
             - uses: actions/checkout@v5
+            - name: Download PHP CLI image
+              uses: actions/download-artifact@v5
+              with:
+                  name: php-8.4-cli
+                  path: .
+            - name: Load PHP CLI image
+              run: docker load -i php-8.4-cli.tar
             - name: Build container
               run: |
-                    docker build -t di-benchmark-${{ matrix.container }} -f containers/${{ matrix.container }}/Dockerfile .
-                    docker save di-benchmark-${{ matrix.container }} -o di-benchmark-${{ matrix.container }}.tar
+                  docker build -t di-benchmark-${{ matrix.container }} -f containers/${{ matrix.container }}/Dockerfile .
+                  docker save di-benchmark-${{ matrix.container }} -o di-benchmark-${{ matrix.container }}.tar
             - name: Upload image
               uses: actions/upload-artifact@v4
               with:
@@ -71,6 +99,7 @@ jobs:
                   path: di-benchmark-${{ matrix.container }}.tar
     build-slow:
         if: github.actor != 'github-actions[bot]'
+        needs: download-php-cli
         runs-on: ubuntu-latest
         strategy:
             matrix:
@@ -84,10 +113,17 @@ jobs:
                     - ray-di.reflection.transient
         steps:
             - uses: actions/checkout@v5
+            - name: Download PHP CLI image
+              uses: actions/download-artifact@v5
+              with:
+                  name: php-8.4-cli
+                  path: .
+            - name: Load PHP CLI image
+              run: docker load -i php-8.4-cli.tar
             - name: Build container
               run: |
-                    docker build -t di-benchmark-${{ matrix.container }} -f containers/${{ matrix.container }}/Dockerfile .
-                    docker save di-benchmark-${{ matrix.container }} -o di-benchmark-${{ matrix.container }}.tar
+                  docker build -t di-benchmark-${{ matrix.container }} -f containers/${{ matrix.container }}/Dockerfile .
+                  docker save di-benchmark-${{ matrix.container }} -o di-benchmark-${{ matrix.container }}.tar
             - name: Upload image
               uses: actions/upload-artifact@v4
               with:
@@ -114,15 +150,6 @@ jobs:
                     - f06_startup
                 run:
                     - 1
-                    - 2
-                    - 3
-                    - 4
-                    - 5
-                    - 6
-                    - 7
-                    - 8
-                    - 9
-                    - 10
         steps:
             - uses: actions/checkout@v5
             - name: Download image
@@ -134,8 +161,8 @@ jobs:
               run: docker load -i di-benchmark-${{ matrix.container }}.tar
             - name: Run benchmarks
               run: |
-                    docker run --rm -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 1 2>&1
-                    mv results.json ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
+                  docker run --rm -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 10 2>&1
+                  mv results.json ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
             - name: Upload results
               uses: actions/upload-artifact@v4
               with:
@@ -173,8 +200,8 @@ jobs:
               run: docker load -i di-benchmark-${{ matrix.container }}.tar
             - name: Run benchmarks
               run: |
-                    docker run --rm -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 10 2>&1
-                    mv results.json ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
+                  docker run --rm -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 10 2>&1
+                  mv results.json ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
             - name: Upload results
               uses: actions/upload-artifact@v4
               with:
@@ -212,8 +239,8 @@ jobs:
               run: docker load -i di-benchmark-${{ matrix.container }}.tar
             - name: Run benchmarks
               run: |
-                    docker run --rm -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 10 2>&1
-                    mv results.json ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
+                  docker run --rm -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 10 2>&1
+                  mv results.json ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
             - name: Upload results
               uses: actions/upload-artifact@v4
               with:
@@ -248,8 +275,8 @@ jobs:
               run: docker load -i di-benchmark-${{ matrix.container }}.tar
             - name: Run benchmarks
               run: |
-                    docker run --rm -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 10 2>&1
-                    mv results.json ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
+                  docker run --rm -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 10 2>&1
+                  mv results.json ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
             - name: Upload results
               uses: actions/upload-artifact@v4
               with:
@@ -284,8 +311,8 @@ jobs:
               run: docker load -i di-benchmark-${{ matrix.container }}.tar
             - name: Run benchmarks
               run: |
-                    docker run --rm -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 10 2>&1
-                    mv results.json ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
+                  docker run --rm -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 10 2>&1
+                  mv results.json ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
             - name: Upload results
               uses: actions/upload-artifact@v4
               with:
@@ -320,8 +347,8 @@ jobs:
               run: docker load -i di-benchmark-${{ matrix.container }}.tar
             - name: Run benchmarks
               run: |
-                    docker run --rm -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 10 2>&1
-                    mv results.json ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
+                  docker run --rm -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 10 2>&1
+                  mv results.json ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
             - name: Upload results
               uses: actions/upload-artifact@v4
               with:
@@ -361,8 +388,8 @@ jobs:
               run: docker load -i di-benchmark-${{ matrix.container }}.tar
             - name: Run benchmarks
               run: |
-                    docker run --rm -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 5 2>&1
-                    mv results.json ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
+                  docker run --rm -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 5 2>&1
+                  mv results.json ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
             - name: Upload results
               uses: actions/upload-artifact@v4
               with:
@@ -410,8 +437,8 @@ jobs:
               run: docker load -i di-benchmark-${{ matrix.container }}.tar
             - name: Run benchmarks
               run: |
-                    docker run --rm -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 1 2>&1
-                    mv results.json ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
+                  docker run --rm -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 1 2>&1
+                  mv results.json ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
             - name: Upload results
               uses: actions/upload-artifact@v4
               with:
@@ -447,8 +474,8 @@ jobs:
               run: docker load -i di-benchmark-${{ matrix.container }}.tar
             - name: Run benchmarks
               run: |
-                    docker run --rm -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 5 2>&1
-                    mv results.json ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
+                  docker run --rm -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 5 2>&1
+                  mv results.json ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
             - name: Upload results
               uses: actions/upload-artifact@v4
               with:
@@ -492,8 +519,8 @@ jobs:
               run: docker load -i di-benchmark-${{ matrix.container }}.tar
             - name: Run benchmarks
               run: |
-                    docker run --rm -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 1 2>&1
-                    mv results.json ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
+                  docker run --rm -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 1 2>&1
+                  mv results.json ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
             - name: Upload results
               uses: actions/upload-artifact@v4
               with:
@@ -540,8 +567,8 @@ jobs:
               run: docker load -i di-benchmark-${{ matrix.container }}.tar
             - name: Run benchmarks
               run: |
-                    docker run --rm -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 1 2>&1
-                    mv results.json ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
+                  docker run --rm -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 1 2>&1
+                  mv results.json ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
             - name: Upload results
               uses: actions/upload-artifact@v4
               with:
@@ -585,8 +612,8 @@ jobs:
               run: docker load -i di-benchmark-${{ matrix.container }}.tar
             - name: Run benchmarks
               run: |
-                    docker run --rm -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 1 2>&1
-                    mv results.json ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
+                  docker run --rm -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 1 2>&1
+                  mv results.json ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
             - name: Upload results
               uses: actions/upload-artifact@v4
               with:
@@ -606,22 +633,22 @@ jobs:
         steps:
             - uses: actions/checkout@v5
             - name: Download results
-              uses: actions/download-artifact@v5
-              with:
-                  pattern: 'result-*-*-*'
-                  merge-multiple: true
+                uses: actions/download-artifact@v5
+                with:
+                    pattern: 'result-*-*-*'
+                    merge-multiple: true
             - name: Merge test results
-              run: php tools/merge_json.php
+                run: php tools/merge_json.php
             - name: Generate graphs
-              run: php tools/generate_graphs.php
+                run: php tools/generate_graphs.php
             - name: Generate run summary
-              run: php tools/generate_run_summary.php
+                run: php tools/generate_run_summary.php
             - name: Generate README
-              run: php tools/generate_readme.php
+                run: php tools/generate_readme.php
             - name: Update workflow
-              run: php tools/update_workflow.php
+                run: php tools/update_workflow.php
             - name: Commit results
-              run: |
+                run: |
                     git config --global user.name 'github-actions[bot]'
                     git config --global user.email 'github-actions[bot]@users.noreply.github.com'
                     git add README.md images/speed_comparison_*.jpg run_summary.yaml proposed-workflow.yml
@@ -630,5 +657,5 @@ jobs:
                     fi
                     git commit -m "Update test results" || echo "No changes to commit"
                     git push
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                env:
+                    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/proposed-workflow.yml
+++ b/proposed-workflow.yml
@@ -28,8 +28,8 @@ jobs:
             - name: Upload PHP CLI image
               uses: actions/upload-artifact@v4
               with:
-                  name: php-8.4-cli
-                  path: php-8.4-cli.tar
+                name: php-8.4-cli
+                path: php-8.4-cli.tar
     build-fast:
         if: github.actor != 'github-actions[bot]'
         needs: download-php-cli
@@ -51,8 +51,8 @@ jobs:
             - name: Download PHP CLI image
               uses: actions/download-artifact@v5
               with:
-                  name: php-8.4-cli
-                  path: .
+                name: php-8.4-cli
+                path: .
             - name: Load PHP CLI image
               run: docker load -i php-8.4-cli.tar
             - name: Build container
@@ -62,8 +62,8 @@ jobs:
             - name: Upload image
               uses: actions/upload-artifact@v4
               with:
-                  name: di-benchmark-${{ matrix.container }}
-                  path: di-benchmark-${{ matrix.container }}.tar
+                name: di-benchmark-${{ matrix.container }}
+                path: di-benchmark-${{ matrix.container }}.tar
     build-medium:
         if: github.actor != 'github-actions[bot]'
         needs: download-php-cli
@@ -84,8 +84,8 @@ jobs:
             - name: Download PHP CLI image
               uses: actions/download-artifact@v5
               with:
-                  name: php-8.4-cli
-                  path: .
+                name: php-8.4-cli
+                path: .
             - name: Load PHP CLI image
               run: docker load -i php-8.4-cli.tar
             - name: Build container
@@ -95,8 +95,8 @@ jobs:
             - name: Upload image
               uses: actions/upload-artifact@v4
               with:
-                  name: di-benchmark-${{ matrix.container }}
-                  path: di-benchmark-${{ matrix.container }}.tar
+                name: di-benchmark-${{ matrix.container }}
+                path: di-benchmark-${{ matrix.container }}.tar
     build-slow:
         if: github.actor != 'github-actions[bot]'
         needs: download-php-cli
@@ -116,8 +116,8 @@ jobs:
             - name: Download PHP CLI image
               uses: actions/download-artifact@v5
               with:
-                  name: php-8.4-cli
-                  path: .
+                name: php-8.4-cli
+                path: .
             - name: Load PHP CLI image
               run: docker load -i php-8.4-cli.tar
             - name: Build container
@@ -127,8 +127,8 @@ jobs:
             - name: Upload image
               uses: actions/upload-artifact@v4
               with:
-                  name: di-benchmark-${{ matrix.container }}
-                  path: di-benchmark-${{ matrix.container }}.tar
+                name: di-benchmark-${{ matrix.container }}
+                path: di-benchmark-${{ matrix.container }}.tar
     benchmark-fast-06:
         if: github.actor != 'github-actions[bot]'
         needs: build-fast
@@ -155,8 +155,8 @@ jobs:
             - name: Download image
               uses: actions/download-artifact@v5
               with:
-                  name: di-benchmark-${{ matrix.container }}
-                  path: .
+                name: di-benchmark-${{ matrix.container }}
+                path: .
             - name: Load image
               run: docker load -i di-benchmark-${{ matrix.container }}.tar
             - name: Run benchmarks
@@ -166,8 +166,8 @@ jobs:
             - name: Upload results
               uses: actions/upload-artifact@v4
               with:
-                  name: result-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}
-                  path: ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
+                name: result-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}
+                path: ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
     benchmark-fast-16:
         if: github.actor != 'github-actions[bot]'
         needs: build-fast
@@ -194,8 +194,8 @@ jobs:
             - name: Download image
               uses: actions/download-artifact@v5
               with:
-                  name: di-benchmark-${{ matrix.container }}
-                  path: .
+                name: di-benchmark-${{ matrix.container }}
+                path: .
             - name: Load image
               run: docker load -i di-benchmark-${{ matrix.container }}.tar
             - name: Run benchmarks
@@ -205,8 +205,8 @@ jobs:
             - name: Upload results
               uses: actions/upload-artifact@v4
               with:
-                  name: result-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}
-                  path: ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
+                name: result-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}
+                path: ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
     benchmark-fast-26:
         if: github.actor != 'github-actions[bot]'
         needs: build-fast
@@ -233,8 +233,8 @@ jobs:
             - name: Download image
               uses: actions/download-artifact@v5
               with:
-                  name: di-benchmark-${{ matrix.container }}
-                  path: .
+                name: di-benchmark-${{ matrix.container }}
+                path: .
             - name: Load image
               run: docker load -i di-benchmark-${{ matrix.container }}.tar
             - name: Run benchmarks
@@ -244,8 +244,8 @@ jobs:
             - name: Upload results
               uses: actions/upload-artifact@v4
               with:
-                  name: result-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}
-                  path: ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
+                name: result-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}
+                path: ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
     benchmark-fast-in-06:
         if: github.actor != 'github-actions[bot]'
         needs: build-fast
@@ -269,8 +269,8 @@ jobs:
             - name: Download image
               uses: actions/download-artifact@v5
               with:
-                  name: di-benchmark-${{ matrix.container }}
-                  path: .
+                name: di-benchmark-${{ matrix.container }}
+                path: .
             - name: Load image
               run: docker load -i di-benchmark-${{ matrix.container }}.tar
             - name: Run benchmarks
@@ -280,8 +280,8 @@ jobs:
             - name: Upload results
               uses: actions/upload-artifact@v4
               with:
-                  name: result-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}
-                  path: ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
+                name: result-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}
+                path: ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
     benchmark-fast-in-16:
         if: github.actor != 'github-actions[bot]'
         needs: build-fast
@@ -305,8 +305,8 @@ jobs:
             - name: Download image
               uses: actions/download-artifact@v5
               with:
-                  name: di-benchmark-${{ matrix.container }}
-                  path: .
+                name: di-benchmark-${{ matrix.container }}
+                path: .
             - name: Load image
               run: docker load -i di-benchmark-${{ matrix.container }}.tar
             - name: Run benchmarks
@@ -316,8 +316,8 @@ jobs:
             - name: Upload results
               uses: actions/upload-artifact@v4
               with:
-                  name: result-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}
-                  path: ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
+                name: result-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}
+                path: ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
     benchmark-fast-in-26:
         if: github.actor != 'github-actions[bot]'
         needs: build-fast
@@ -341,8 +341,8 @@ jobs:
             - name: Download image
               uses: actions/download-artifact@v5
               with:
-                  name: di-benchmark-${{ matrix.container }}
-                  path: .
+                name: di-benchmark-${{ matrix.container }}
+                path: .
             - name: Load image
               run: docker load -i di-benchmark-${{ matrix.container }}.tar
             - name: Run benchmarks
@@ -352,8 +352,8 @@ jobs:
             - name: Upload results
               uses: actions/upload-artifact@v4
               with:
-                  name: result-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}
-                  path: ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
+                name: result-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}
+                path: ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
     benchmark-medium-06:
         if: github.actor != 'github-actions[bot]'
         needs:
@@ -382,8 +382,8 @@ jobs:
             - name: Download image
               uses: actions/download-artifact@v5
               with:
-                  name: di-benchmark-${{ matrix.container }}
-                  path: .
+                name: di-benchmark-${{ matrix.container }}
+                path: .
             - name: Load image
               run: docker load -i di-benchmark-${{ matrix.container }}.tar
             - name: Run benchmarks
@@ -393,8 +393,8 @@ jobs:
             - name: Upload results
               uses: actions/upload-artifact@v4
               with:
-                  name: result-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}
-                  path: ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
+                name: result-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}
+                path: ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
     benchmark-medium-16:
         if: github.actor != 'github-actions[bot]'
         needs:
@@ -431,8 +431,8 @@ jobs:
             - name: Download image
               uses: actions/download-artifact@v5
               with:
-                  name: di-benchmark-${{ matrix.container }}
-                  path: .
+                name: di-benchmark-${{ matrix.container }}
+                path: .
             - name: Load image
               run: docker load -i di-benchmark-${{ matrix.container }}.tar
             - name: Run benchmarks
@@ -442,8 +442,8 @@ jobs:
             - name: Upload results
               uses: actions/upload-artifact@v4
               with:
-                  name: result-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}
-                  path: ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
+                name: result-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}
+                path: ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
     benchmark-medium-in-06:
         if: github.actor != 'github-actions[bot]'
         needs:
@@ -468,8 +468,8 @@ jobs:
             - name: Download image
               uses: actions/download-artifact@v5
               with:
-                  name: di-benchmark-${{ matrix.container }}
-                  path: .
+                name: di-benchmark-${{ matrix.container }}
+                path: .
             - name: Load image
               run: docker load -i di-benchmark-${{ matrix.container }}.tar
             - name: Run benchmarks
@@ -479,8 +479,8 @@ jobs:
             - name: Upload results
               uses: actions/upload-artifact@v4
               with:
-                  name: result-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}
-                  path: ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
+                name: result-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}
+                path: ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
     benchmark-medium-in-16:
         if: github.actor != 'github-actions[bot]'
         needs:
@@ -513,8 +513,8 @@ jobs:
             - name: Download image
               uses: actions/download-artifact@v5
               with:
-                  name: di-benchmark-${{ matrix.container }}
-                  path: .
+                name: di-benchmark-${{ matrix.container }}
+                path: .
             - name: Load image
               run: docker load -i di-benchmark-${{ matrix.container }}.tar
             - name: Run benchmarks
@@ -524,8 +524,8 @@ jobs:
             - name: Upload results
               uses: actions/upload-artifact@v4
               with:
-                  name: result-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}
-                  path: ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
+                name: result-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}
+                path: ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
     benchmark-slow-06:
         if: github.actor != 'github-actions[bot]'
         needs:
@@ -561,8 +561,8 @@ jobs:
             - name: Download image
               uses: actions/download-artifact@v5
               with:
-                  name: di-benchmark-${{ matrix.container }}
-                  path: .
+                name: di-benchmark-${{ matrix.container }}
+                path: .
             - name: Load image
               run: docker load -i di-benchmark-${{ matrix.container }}.tar
             - name: Run benchmarks
@@ -572,8 +572,8 @@ jobs:
             - name: Upload results
               uses: actions/upload-artifact@v4
               with:
-                  name: result-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}
-                  path: ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
+                name: result-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}
+                path: ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
     benchmark-slow-in-06:
         if: github.actor != 'github-actions[bot]'
         needs:
@@ -606,8 +606,8 @@ jobs:
             - name: Download image
               uses: actions/download-artifact@v5
               with:
-                  name: di-benchmark-${{ matrix.container }}
-                  path: .
+                name: di-benchmark-${{ matrix.container }}
+                path: .
             - name: Load image
               run: docker load -i di-benchmark-${{ matrix.container }}.tar
             - name: Run benchmarks
@@ -617,8 +617,8 @@ jobs:
             - name: Upload results
               uses: actions/upload-artifact@v4
               with:
-                  name: result-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}
-                  path: ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
+                name: result-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}
+                path: ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
     aggregate:
         if: github.actor != 'github-actions[bot]'
         needs:

--- a/tools/update_workflow.php
+++ b/tools/update_workflow.php
@@ -47,6 +47,7 @@ function format_list(array $items, int $level): string {
 function build_job(string $name, array $containers): string {
     $yaml  = indent(1) . "$name:\n";
     $yaml .= indent(2) . "if: github.actor != 'github-actions[bot]'\n";
+    $yaml .= indent(2) . "needs: download-php-cli\n";
     $yaml .= indent(2) . "runs-on: ubuntu-latest\n";
     $yaml .= indent(2) . "strategy:\n";
     $yaml .= indent(3) . "matrix:\n";
@@ -54,15 +55,22 @@ function build_job(string $name, array $containers): string {
     $yaml .= format_list($containers, 5);
     $yaml .= indent(2) . "steps:\n";
     $yaml .= indent(3) . "- uses: actions/checkout@v5\n";
+    $yaml .= indent(3) . "- name: Download PHP CLI image\n";
+    $yaml .= indent(3) . "  uses: actions/download-artifact@v5\n";
+    $yaml .= indent(3) . "  with:\n";
+    $yaml .= indent(4) . "  name: php-8.4-cli\n";
+    $yaml .= indent(4) . "  path: .\n";
+    $yaml .= indent(3) . "- name: Load PHP CLI image\n";
+    $yaml .= indent(3) . "  run: docker load -i php-8.4-cli.tar\n";
     $yaml .= indent(3) . "- name: Build container\n";
-    $yaml .= indent(4) . "run: |\n";
-    $yaml .= indent(5) . 'docker build -t di-benchmark-${{ matrix.container }} -f containers/${{ matrix.container }}/Dockerfile .' . "\n";
-    $yaml .= indent(5) . 'docker save di-benchmark-${{ matrix.container }} -o di-benchmark-${{ matrix.container }}.tar' . "\n";
+    $yaml .= indent(3) . "  run: |\n";
+    $yaml .= indent(4) . '  docker build -t di-benchmark-${{ matrix.container }} -f containers/${{ matrix.container }}/Dockerfile .' . "\n";
+    $yaml .= indent(4) . '  docker save di-benchmark-${{ matrix.container }} -o di-benchmark-${{ matrix.container }}.tar' . "\n";
     $yaml .= indent(3) . "- name: Upload image\n";
-    $yaml .= indent(4) . "uses: actions/upload-artifact@v4\n";
-    $yaml .= indent(4) . "with:\n";
-    $yaml .= indent(5) . 'name: di-benchmark-${{ matrix.container }}' . "\n";
-    $yaml .= indent(5) . 'path: di-benchmark-${{ matrix.container }}.tar' . "\n";
+    $yaml .= indent(3) . "  uses: actions/upload-artifact@v4\n";
+    $yaml .= indent(3) . "  with:\n";
+    $yaml .= indent(4) . '  name: di-benchmark-${{ matrix.container }}' . "\n";
+    $yaml .= indent(4) . '  path: di-benchmark-${{ matrix.container }}.tar' . "\n";
     return $yaml;
 }
 
@@ -87,21 +95,21 @@ function benchmark_job(string $name, array $needs, array $containers, array $tes
     $yaml .= indent(2) . "steps:\n";
     $yaml .= indent(3) . "- uses: actions/checkout@v5\n";
     $yaml .= indent(3) . "- name: Download image\n";
-    $yaml .= indent(4) . "uses: actions/download-artifact@v5\n";
-    $yaml .= indent(4) . "with:\n";
-    $yaml .= indent(5) . 'name: di-benchmark-${{ matrix.container }}' . "\n";
-    $yaml .= indent(5) . "path: .\n";
+    $yaml .= indent(3) . "  uses: actions/download-artifact@v5\n";
+    $yaml .= indent(3) . "  with:\n";
+    $yaml .= indent(4) . '  name: di-benchmark-${{ matrix.container }}' . "\n";
+    $yaml .= indent(4) . "  path: .\n";
     $yaml .= indent(3) . "- name: Load image\n";
-    $yaml .= indent(4) . 'run: docker load -i di-benchmark-${{ matrix.container }}.tar' . "\n";
+    $yaml .= indent(3) . '  run: docker load -i di-benchmark-${{ matrix.container }}.tar' . "\n";
     $yaml .= indent(3) . "- name: Run benchmarks\n";
-    $yaml .= indent(4) . "run: |\n";
-    $yaml .= indent(5) . 'docker run --rm -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} ' . $iterations . " 2>&1\n";
-    $yaml .= indent(5) . 'mv results.json ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json' . "\n";
+    $yaml .= indent(3) . "  run: |\n";
+    $yaml .= indent(4) . '  docker run --rm -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} ' . $iterations . " 2>&1\n";
+    $yaml .= indent(4) . '  mv results.json ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json' . "\n";
     $yaml .= indent(3) . "- name: Upload results\n";
-    $yaml .= indent(4) . "uses: actions/upload-artifact@v4\n";
-    $yaml .= indent(4) . "with:\n";
-    $yaml .= indent(5) . 'name: result-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}' . "\n";
-    $yaml .= indent(5) . 'path: ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json' . "\n";
+    $yaml .= indent(3) . "  uses: actions/upload-artifact@v4\n";
+    $yaml .= indent(3) . "  with:\n";
+    $yaml .= indent(4) . '  name: result-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}' . "\n";
+    $yaml .= indent(4) . '  path: ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json' . "\n";
     return $yaml;
 }
 
@@ -176,6 +184,18 @@ jobs:
 YAML;
 
     $yaml = $header;
+    $yaml .= indent(1) . "download-php-cli:\n";
+    $yaml .= indent(2) . "runs-on: ubuntu-latest\n";
+    $yaml .= indent(2) . "steps:\n";
+    $yaml .= indent(3) . "- name: Pull PHP CLI image\n";
+    $yaml .= indent(3) . "  run: docker pull php:8.4-cli\n";
+    $yaml .= indent(3) . "- name: Save PHP CLI image\n";
+    $yaml .= indent(3) . "  run: docker save php:8.4-cli -o php-8.4-cli.tar\n";
+    $yaml .= indent(3) . "- name: Upload PHP CLI image\n";
+    $yaml .= indent(3) . "  uses: actions/upload-artifact@v4\n";
+    $yaml .= indent(3) . "  with:\n";
+    $yaml .= indent(4) . "  name: php-8.4-cli\n";
+    $yaml .= indent(4) . "  path: php-8.4-cli.tar\n";
     $yaml .= build_job('build-fast', $fast);
     $yaml .= build_job('build-medium', $medium);
     $yaml .= build_job('build-slow', $slow);

--- a/tools/update_workflow.php
+++ b/tools/update_workflow.php
@@ -58,8 +58,8 @@ function build_job(string $name, array $containers): string {
     $yaml .= indent(3) . "- name: Download PHP CLI image\n";
     $yaml .= indent(3) . "  uses: actions/download-artifact@v5\n";
     $yaml .= indent(3) . "  with:\n";
-    $yaml .= indent(4) . "  name: php-8.4-cli\n";
-    $yaml .= indent(4) . "  path: .\n";
+    $yaml .= indent(4) . "name: php-8.4-cli\n";
+    $yaml .= indent(4) . "path: .\n";
     $yaml .= indent(3) . "- name: Load PHP CLI image\n";
     $yaml .= indent(3) . "  run: docker load -i php-8.4-cli.tar\n";
     $yaml .= indent(3) . "- name: Build container\n";
@@ -69,8 +69,8 @@ function build_job(string $name, array $containers): string {
     $yaml .= indent(3) . "- name: Upload image\n";
     $yaml .= indent(3) . "  uses: actions/upload-artifact@v4\n";
     $yaml .= indent(3) . "  with:\n";
-    $yaml .= indent(4) . '  name: di-benchmark-${{ matrix.container }}' . "\n";
-    $yaml .= indent(4) . '  path: di-benchmark-${{ matrix.container }}.tar' . "\n";
+    $yaml .= indent(4) . 'name: di-benchmark-${{ matrix.container }}' . "\n";
+    $yaml .= indent(4) . 'path: di-benchmark-${{ matrix.container }}.tar' . "\n";
     return $yaml;
 }
 
@@ -97,8 +97,8 @@ function benchmark_job(string $name, array $needs, array $containers, array $tes
     $yaml .= indent(3) . "- name: Download image\n";
     $yaml .= indent(3) . "  uses: actions/download-artifact@v5\n";
     $yaml .= indent(3) . "  with:\n";
-    $yaml .= indent(4) . '  name: di-benchmark-${{ matrix.container }}' . "\n";
-    $yaml .= indent(4) . "  path: .\n";
+    $yaml .= indent(4) . 'name: di-benchmark-${{ matrix.container }}' . "\n";
+    $yaml .= indent(4) . "path: .\n";
     $yaml .= indent(3) . "- name: Load image\n";
     $yaml .= indent(3) . '  run: docker load -i di-benchmark-${{ matrix.container }}.tar' . "\n";
     $yaml .= indent(3) . "- name: Run benchmarks\n";
@@ -108,8 +108,8 @@ function benchmark_job(string $name, array $needs, array $containers, array $tes
     $yaml .= indent(3) . "- name: Upload results\n";
     $yaml .= indent(3) . "  uses: actions/upload-artifact@v4\n";
     $yaml .= indent(3) . "  with:\n";
-    $yaml .= indent(4) . '  name: result-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}' . "\n";
-    $yaml .= indent(4) . '  path: ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json' . "\n";
+    $yaml .= indent(4) . 'name: result-${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}' . "\n";
+    $yaml .= indent(4) . 'path: ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json' . "\n";
     return $yaml;
 }
 
@@ -194,8 +194,8 @@ YAML;
     $yaml .= indent(3) . "- name: Upload PHP CLI image\n";
     $yaml .= indent(3) . "  uses: actions/upload-artifact@v4\n";
     $yaml .= indent(3) . "  with:\n";
-    $yaml .= indent(4) . "  name: php-8.4-cli\n";
-    $yaml .= indent(4) . "  path: php-8.4-cli.tar\n";
+    $yaml .= indent(4) . "name: php-8.4-cli\n";
+    $yaml .= indent(4) . "path: php-8.4-cli.tar\n";
     $yaml .= build_job('build-fast', $fast);
     $yaml .= build_job('build-medium', $medium);
     $yaml .= build_job('build-slow', $slow);


### PR DESCRIPTION
## Summary
- Pull and upload PHP 8.4 CLI image once, reuse across container builds
- Update build jobs to load cached PHP image before building
- Fix step indentation and propagate changes to actual workflow

## Testing
- `php -l tools/update_workflow.php`


------
https://chatgpt.com/codex/tasks/task_e_68c18c0b3d30832f8f727c048ab4e705

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - CI pipeline now prepares and reuses a standardized PHP CLI base image across builds and benchmarks for faster, more consistent runs.
  - Build jobs depend on the prepared image and load it before container builds.

- Tests
  - Benchmark workflows now run with increased iterations (from 1 to 10) for more stable, comparable results.
  - One fast benchmark matrix reduced to a single run to streamline execution.

- Style
  - Formatting/indentation cleanups in workflow steps with no behavioral changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->