### PR TITLE
Include interfaces in Quickly compiled container classmap

### DIFF
--- a/containers/quickly.compiled.singleton/composer.json
+++ b/containers/quickly.compiled.singleton/composer.json
@@ -6,7 +6,10 @@
         "classmap": [
             "classes-06.php",
             "classes-16.php",
-            "classes-26.php"
+            "classes-26.php",
+            "interfaces-06.php",
+            "interfaces-16.php",
+            "interfaces-26.php"
         ]
     },
     "config": {


### PR DESCRIPTION
## Summary
- remove custom interface fallback and rely on Quickly's default behavior
- add interface classmap files to `composer.json` for Quickly compiled container

## Testing
- `php -l containers/quickly.compiled.singleton/AdapterImplementation.php`
- ⚠️ `docker run --rm -v "$PWD:/out" di-benchmark-quickly.compiled.singleton php benchmark.php fin06 10` (docker not available)


------
https://chatgpt.com/codex/tasks/task_e_68c19c77dd64832f985eda1366568230