### PR TITLE
Fix indentation of aggregate job

### DIFF
--- a/.github/workflows/update-test-results.yml
+++ b/.github/workflows/update-test-results.yml
@@ -633,29 +633,29 @@ jobs:
         steps:
             - uses: actions/checkout@v5
             - name: Download results
-                uses: actions/download-artifact@v5
-                with:
-                    pattern: 'result-*-*-*'
-                    merge-multiple: true
+              uses: actions/download-artifact@v5
+              with:
+                pattern: 'result-*-*-*'
+                merge-multiple: true
             - name: Merge test results
-                run: php tools/merge_json.php
+              run: php tools/merge_json.php
             - name: Generate graphs
-                run: php tools/generate_graphs.php
+              run: php tools/generate_graphs.php
             - name: Generate run summary
-                run: php tools/generate_run_summary.php
+              run: php tools/generate_run_summary.php
             - name: Generate README
-                run: php tools/generate_readme.php
+              run: php tools/generate_readme.php
             - name: Update workflow
-                run: php tools/update_workflow.php
+              run: php tools/update_workflow.php
             - name: Commit results
-                run: |
-                    git config --global user.name 'github-actions[bot]'
-                    git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-                    git add README.md images/speed_comparison_*.jpg run_summary.yaml proposed-workflow.yml
-                    if [ "$GITHUB_EVENT_NAME" = "schedule" ]; then
-                        git add archive
-                    fi
-                    git commit -m "Update test results" || echo "No changes to commit"
-                    git push
-                env:
-                    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                git config --global user.name 'github-actions[bot]'
+                git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+                git add README.md images/speed_comparison_*.jpg run_summary.yaml proposed-workflow.yml
+                if [ "$GITHUB_EVENT_NAME" = "schedule" ]; then
+                    git add archive
+                fi
+                git commit -m "Update test results" || echo "No changes to commit"
+                git push
+              env:
+                GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/proposed-workflow.yml
+++ b/proposed-workflow.yml
@@ -633,29 +633,29 @@ jobs:
         steps:
             - uses: actions/checkout@v5
             - name: Download results
-                uses: actions/download-artifact@v5
-                with:
-                    pattern: 'result-*-*-*'
-                    merge-multiple: true
+              uses: actions/download-artifact@v5
+              with:
+                pattern: 'result-*-*-*'
+                merge-multiple: true
             - name: Merge test results
-                run: php tools/merge_json.php
+              run: php tools/merge_json.php
             - name: Generate graphs
-                run: php tools/generate_graphs.php
+              run: php tools/generate_graphs.php
             - name: Generate run summary
-                run: php tools/generate_run_summary.php
+              run: php tools/generate_run_summary.php
             - name: Generate README
-                run: php tools/generate_readme.php
+              run: php tools/generate_readme.php
             - name: Update workflow
-                run: php tools/update_workflow.php
+              run: php tools/update_workflow.php
             - name: Commit results
-                run: |
-                    git config --global user.name 'github-actions[bot]'
-                    git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-                    git add README.md images/speed_comparison_*.jpg run_summary.yaml proposed-workflow.yml
-                    if [ "$GITHUB_EVENT_NAME" = "schedule" ]; then
-                        git add archive
-                    fi
-                    git commit -m "Update test results" || echo "No changes to commit"
-                    git push
-                env:
-                    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                git config --global user.name 'github-actions[bot]'
+                git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+                git add README.md images/speed_comparison_*.jpg run_summary.yaml proposed-workflow.yml
+                if [ "$GITHUB_EVENT_NAME" = "schedule" ]; then
+                    git add archive
+                fi
+                git commit -m "Update test results" || echo "No changes to commit"
+                git push
+              env:
+                GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/tools/update_workflow.php
+++ b/tools/update_workflow.php
@@ -129,32 +129,32 @@ function aggregate_job(): string {
         steps:
             - uses: actions/checkout@v5
             - name: Download results
-                uses: actions/download-artifact@v5
-                with:
-                    pattern: 'result-*-*-*'
-                    merge-multiple: true
+              uses: actions/download-artifact@v5
+              with:
+                pattern: 'result-*-*-*'
+                merge-multiple: true
             - name: Merge test results
-                run: php tools/merge_json.php
+              run: php tools/merge_json.php
             - name: Generate graphs
-                run: php tools/generate_graphs.php
+              run: php tools/generate_graphs.php
             - name: Generate run summary
-                run: php tools/generate_run_summary.php
+              run: php tools/generate_run_summary.php
             - name: Generate README
-                run: php tools/generate_readme.php
+              run: php tools/generate_readme.php
             - name: Update workflow
-                run: php tools/update_workflow.php
+              run: php tools/update_workflow.php
             - name: Commit results
-                run: |
-                    git config --global user.name 'github-actions[bot]'
-                    git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-                    git add README.md images/speed_comparison_*.jpg run_summary.yaml proposed-workflow.yml
-                    if [ "$GITHUB_EVENT_NAME" = "schedule" ]; then
-                        git add archive
-                    fi
-                    git commit -m "Update test results" || echo "No changes to commit"
-                    git push
-                env:
-                    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                git config --global user.name 'github-actions[bot]'
+                git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+                git add README.md images/speed_comparison_*.jpg run_summary.yaml proposed-workflow.yml
+                if [ "$GITHUB_EVENT_NAME" = "schedule" ]; then
+                    git add archive
+                fi
+                git commit -m "Update test results" || echo "No changes to commit"
+                git push
+              env:
+                GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 YAML;
 }
 
@@ -274,4 +274,4 @@ foreach ($containers as $container) {
 }
 
 $workflow = build_workflow($fast, $medium, $slow);
-file_put_contents('proposed-workflow.yml', $workflow);
+file_put_contents('proposed-workflow.yml', $workflow . "\n");


### PR DESCRIPTION
## Summary
- fix aggregate job indentation in workflow and generator
- ensure generated workflow file ends with newline

## Testing
- `php -l tools/update_workflow.php`


------
https://chatgpt.com/codex/tasks/task_e_68c19d5a8928832fa2ac72692e347e07