### PR TITLE
Fix Aura.Di type resolution for interface benchmarks

### DIFF
--- a/containers/aura-di.configured.transient/AdapterImplementation.php
+++ b/containers/aura-di.configured.transient/AdapterImplementation.php
@@ -17,6 +17,7 @@ class AdapterImplementation
                 $interface = $letter . 'In' . $suffix;
                 $implementation = $letter . 'Im' . $suffix;
                 $c->set($interface, $c->lazyNew($implementation));
+                $c->types[$interface] = $c->lazyGet($interface);
             }
         }
         $this->container = $c;


### PR DESCRIPTION
## Summary
- Map benchmark interfaces to their implementations using lazy service references for Aura.Di

## Testing
- `php -l containers/aura-di.configured.transient/AdapterImplementation.php`
- `php -r 'require "vendor/autoload.php"; require "containers/aura-di.configured.transient/AdapterImplementation.php"; require "src/classes-06.php"; require "src/interfaces-06.php"; $adapter=new AdapterImplementation(); $obj=$adapter->get(FIn06::class); echo get_class($obj),"\n";'`
- `docker build -t di-benchmark-aura-di.configured.transient -f containers/aura-di.configured.transient/Dockerfile .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c19fdfb184832faa10836ff8eeeda3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.

- Bug Fixes
  - Improved reliability of service resolution in the dependency container, preventing occasional failures when retrieving services by interface.

- Chores
  - Internal container configuration refined to better align interface mappings with service retrieval behavior.

- Tests
  - None.

- Documentation
  - None.

- Refactor
  - None.

- Style
  - None.

- Revert
  - None.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->