### PR TITLE
Ensure raw PHP benchmark always in fast group

### DIFF
--- a/proposed-workflow.yml
+++ b/proposed-workflow.yml
@@ -37,8 +37,8 @@ jobs:
         strategy:
             matrix:
                 container:
+                    - php-baseline
                     - laminas-servicemanager.reflection.singleton
-                    - nette-di.compiled.singleton
                     - php-di.reflection.singleton
                     - pimple.configured.singleton
                     - quickly.compiled.singleton
@@ -76,8 +76,8 @@ jobs:
                     - dice.reflection.transient
                     - laravel.reflection.singleton
                     - laravel.reflection.transient
+                    - nette-di.compiled.singleton
                     - phalcon.configured.singleton
-                    - php-baseline
                     - pimple.configured.transient
         steps:
             - uses: actions/checkout@v5
@@ -136,8 +136,8 @@ jobs:
         strategy:
             matrix:
                 container:
+                    - php-baseline
                     - laminas-servicemanager.reflection.singleton
-                    - nette-di.compiled.singleton
                     - php-di.reflection.singleton
                     - pimple.configured.singleton
                     - quickly.compiled.singleton
@@ -175,8 +175,8 @@ jobs:
         strategy:
             matrix:
                 container:
+                    - php-baseline
                     - laminas-servicemanager.reflection.singleton
-                    - nette-di.compiled.singleton
                     - php-di.reflection.singleton
                     - pimple.configured.singleton
                     - quickly.compiled.singleton
@@ -214,8 +214,8 @@ jobs:
         strategy:
             matrix:
                 container:
+                    - php-baseline
                     - laminas-servicemanager.reflection.singleton
-                    - nette-di.compiled.singleton
                     - php-di.reflection.singleton
                     - pimple.configured.singleton
                     - quickly.compiled.singleton
@@ -253,7 +253,6 @@ jobs:
         strategy:
             matrix:
                 container:
-                    - nette-di.compiled.singleton
                     - pimple.configured.singleton
                     - quickly.compiled.singleton
                     - quickly.configured.singleton
@@ -289,7 +288,6 @@ jobs:
         strategy:
             matrix:
                 container:
-                    - nette-di.compiled.singleton
                     - pimple.configured.singleton
                     - quickly.compiled.singleton
                     - quickly.configured.singleton
@@ -325,7 +323,6 @@ jobs:
         strategy:
             matrix:
                 container:
-                    - nette-di.compiled.singleton
                     - pimple.configured.singleton
                     - quickly.compiled.singleton
                     - quickly.configured.singleton
@@ -368,8 +365,8 @@ jobs:
                     - dice.reflection.transient
                     - laravel.reflection.singleton
                     - laravel.reflection.transient
+                    - nette-di.compiled.singleton
                     - phalcon.configured.singleton
-                    - php-baseline
                     - pimple.configured.transient
                 test:
                     - f06
@@ -409,8 +406,8 @@ jobs:
                     - dice.reflection.transient
                     - laravel.reflection.singleton
                     - laravel.reflection.transient
+                    - nette-di.compiled.singleton
                     - phalcon.configured.singleton
-                    - php-baseline
                     - pimple.configured.transient
                 test:
                     - p16
@@ -455,6 +452,7 @@ jobs:
                 container:
                     - aura-di.configured.transient
                     - dice.configured.singleton
+                    - nette-di.compiled.singleton
                     - phalcon.configured.singleton
                     - pimple.configured.transient
                 test:
@@ -492,6 +490,7 @@ jobs:
                 container:
                     - aura-di.configured.transient
                     - dice.configured.singleton
+                    - nette-di.compiled.singleton
                     - phalcon.configured.singleton
                     - pimple.configured.transient
                 test:

--- a/tools/update_workflow.php
+++ b/tools/update_workflow.php
@@ -238,6 +238,10 @@ $metrics = ['f06', 'p16', 'z26'];
 $scores = [];
 
 foreach ($containers as $container) {
+    if ($container === 'php-baseline') {
+        $fast[] = $container;
+        continue;
+    }
     $maxValue = null;
     foreach ($metrics as $metric) {
         $value = $summary[$container][$metric] ?? null;
@@ -260,6 +264,9 @@ $fastThreshold = $values[(int) floor($count / 3)] ?? 0;
 $mediumThreshold = $values[(int) floor(2 * $count / 3)] ?? 0;
 
 foreach ($containers as $container) {
+    if ($container === 'php-baseline') {
+        continue;
+    }
     $score = $scores[$container] ?? null;
     if ($score === null) {
         continue;


### PR DESCRIPTION
## Summary
- Always classify `php-baseline` as a fast container in `update_workflow.php`
- Regenerate `proposed-workflow.yml` so `php-baseline` runs in fast jobs

## Testing
- `php -l tools/update_workflow.php`
- `php tools/update_workflow.php`


------
https://chatgpt.com/codex/tasks/task_e_68c1a376b620832fb38363b7bfba3c8b