### PR TITLE
Fix Dice container interface mapping

### DIFF
--- a/containers/dice.configured.singleton/AdapterImplementation.php
+++ b/containers/dice.configured.singleton/AdapterImplementation.php
@@ -59,26 +59,20 @@ class AdapterImplementation
             A26::class => [],
         ];
         foreach ($definitions as $class => $deps) {
-            $this->container->addRule(
+            $this->container = $this->container->addRule(
                 $class,
-                ['shared' => true,'constructParams' => array_map(fn($d) => [Dice::INSTANCE => $d], $deps)]
+                ['shared' => true, 'constructParams' => array_map(fn($d) => [Dice::INSTANCE => $d], $deps)]
             );
-        }
-        $interfaces = [];
-        foreach ($definitions as $class => $deps) {
             $iface = substr($class, 0, 1) . 'In' . substr($class, 1);
             $impl = substr($class, 0, 1) . 'Im' . substr($class, 1);
             $ifaceDeps = array_map(fn($d) => substr($d, 0, 1) . 'In' . substr($d, 1), $deps);
-            $interfaces[$iface] = [$impl, $ifaceDeps];
-        }
-        foreach ($interfaces as $iface => [$impl, $deps]) {
-            $this->container->addRule(
+            $this->container = $this->container->addRule(
+                $impl,
+                ['shared' => true, 'constructParams' => array_map(fn($d) => [Dice::INSTANCE => $d], $ifaceDeps)]
+            );
+            $this->container = $this->container->addRule(
                 $iface,
-                [
-                    'shared' => true,
-                    'instanceOf' => $impl,
-                    'constructParams' => array_map(fn($d) => [Dice::INSTANCE => $d], $deps),
-                ]
+                ['shared' => true, 'instanceOf' => $impl]
             );
         }
     }


### PR DESCRIPTION
## Summary
- ensure Dice addRule results are stored when registering class, implementation, and interface rules

## Testing
- `php -l containers/dice.configured.singleton/AdapterImplementation.php`
- `php -r "require 'vendor/autoload.php'; require '../../src/classes-06.php'; require '../../src/interfaces-06.php'; require 'AdapterImplementation.php'; var_dump((new AdapterImplementation())->get('FIn06'));"`

------
https://chatgpt.com/codex/tasks/task_e_68c1a3e5a6c8832f808a6e49dc454f41