### PR TITLE
Fix Dice configured container interface mapping

### DIFF
--- a/containers/dice.configured.singleton/AdapterImplementation.php
+++ b/containers/dice.configured.singleton/AdapterImplementation.php
@@ -7,7 +7,6 @@ class AdapterImplementation
     private Dice $container;
     public function __construct()
     {
-        $this->container = new Dice();
         $definitions = [
             F06::class => [E06::class, D06::class, B06::class],
             E06::class => [D06::class, C06::class, B06::class],
@@ -58,23 +57,25 @@ class AdapterImplementation
             B26::class => [A26::class],
             A26::class => [],
         ];
+        $rules = [];
         foreach ($definitions as $class => $deps) {
-            $this->container = $this->container->addRule(
-                $class,
-                ['shared' => true, 'constructParams' => array_map(fn($d) => [Dice::INSTANCE => $d], $deps)]
-            );
+            $rules[$class] = [
+                'shared' => true,
+                'constructParams' => array_map(fn($d) => [Dice::INSTANCE => $d], $deps),
+            ];
             $iface = substr($class, 0, 1) . 'In' . substr($class, 1);
             $impl = substr($class, 0, 1) . 'Im' . substr($class, 1);
             $ifaceDeps = array_map(fn($d) => substr($d, 0, 1) . 'In' . substr($d, 1), $deps);
-            $this->container = $this->container->addRule(
-                $impl,
-                ['shared' => true, 'constructParams' => array_map(fn($d) => [Dice::INSTANCE => $d], $ifaceDeps)]
-            );
-            $this->container = $this->container->addRule(
-                $iface,
-                ['shared' => true, 'instanceOf' => $impl]
-            );
+            $rules[$impl] = [
+                'shared' => true,
+                'constructParams' => array_map(fn($d) => [Dice::INSTANCE => $d], $ifaceDeps),
+            ];
+            $rules[$iface] = [
+                'shared' => true,
+                'instanceOf' => $impl,
+            ];
         }
+        $this->container = (new Dice())->addRules($rules);
     }
     public function get(string $class): object
     {


### PR DESCRIPTION
## Summary
- configure Dice using `addRules` to register all class and interface bindings at once

## Testing
- `php -l containers/dice.configured.singleton/AdapterImplementation.php`
- `php -r 'require "vendor/autoload.php"; require "containers/dice.configured.singleton/AdapterImplementation.php"; require "src/classes-06.php"; require "src/interfaces-06.php"; $adapter=new AdapterImplementation(); $obj=$adapter->get("FIn06"); var_dump(get_class($obj));'`


------
https://chatgpt.com/codex/tasks/task_e_68c1bd880774832fa533ac154bf4c45c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined dependency container configuration by batching rule application, simplifying setup without changing public behavior or APIs.

* **Performance**
  * Reduced initialization overhead for dependency setup, improving startup responsiveness and efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->