### PR TITLE
Limit resources for benchmark Docker runs

### DIFF
--- a/.github/workflows/update-test-results.yml
+++ b/.github/workflows/update-test-results.yml
@@ -161,7 +161,7 @@ jobs:
               run: docker load -i di-benchmark-${{ matrix.container }}.tar
             - name: Run benchmarks
               run: |
-                  docker run --rm -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 10 2>&1
+                  docker run --rm --memory=512m --memory-swap=512m --cpus=1.0 --pids-limit=100 -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 10 2>&1
                   mv results.json ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
             - name: Upload results
               uses: actions/upload-artifact@v4
@@ -200,7 +200,7 @@ jobs:
               run: docker load -i di-benchmark-${{ matrix.container }}.tar
             - name: Run benchmarks
               run: |
-                  docker run --rm -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 10 2>&1
+                  docker run --rm --memory=512m --memory-swap=512m --cpus=1.0 --pids-limit=100 -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 10 2>&1
                   mv results.json ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
             - name: Upload results
               uses: actions/upload-artifact@v4
@@ -239,7 +239,7 @@ jobs:
               run: docker load -i di-benchmark-${{ matrix.container }}.tar
             - name: Run benchmarks
               run: |
-                  docker run --rm -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 10 2>&1
+                  docker run --rm --memory=512m --memory-swap=512m --cpus=1.0 --pids-limit=100 -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 10 2>&1
                   mv results.json ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
             - name: Upload results
               uses: actions/upload-artifact@v4
@@ -275,7 +275,7 @@ jobs:
               run: docker load -i di-benchmark-${{ matrix.container }}.tar
             - name: Run benchmarks
               run: |
-                  docker run --rm -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 10 2>&1
+                  docker run --rm --memory=512m --memory-swap=512m --cpus=1.0 --pids-limit=100 -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 10 2>&1
                   mv results.json ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
             - name: Upload results
               uses: actions/upload-artifact@v4
@@ -311,7 +311,7 @@ jobs:
               run: docker load -i di-benchmark-${{ matrix.container }}.tar
             - name: Run benchmarks
               run: |
-                  docker run --rm -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 10 2>&1
+                  docker run --rm --memory=512m --memory-swap=512m --cpus=1.0 --pids-limit=100 -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 10 2>&1
                   mv results.json ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
             - name: Upload results
               uses: actions/upload-artifact@v4
@@ -347,7 +347,7 @@ jobs:
               run: docker load -i di-benchmark-${{ matrix.container }}.tar
             - name: Run benchmarks
               run: |
-                  docker run --rm -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 10 2>&1
+                  docker run --rm --memory=512m --memory-swap=512m --cpus=1.0 --pids-limit=100 -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 10 2>&1
                   mv results.json ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
             - name: Upload results
               uses: actions/upload-artifact@v4
@@ -388,7 +388,7 @@ jobs:
               run: docker load -i di-benchmark-${{ matrix.container }}.tar
             - name: Run benchmarks
               run: |
-                  docker run --rm -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 5 2>&1
+                  docker run --rm --memory=512m --memory-swap=512m --cpus=1.0 --pids-limit=100 -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 5 2>&1
                   mv results.json ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
             - name: Upload results
               uses: actions/upload-artifact@v4
@@ -437,7 +437,7 @@ jobs:
               run: docker load -i di-benchmark-${{ matrix.container }}.tar
             - name: Run benchmarks
               run: |
-                  docker run --rm -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 1 2>&1
+                  docker run --rm --memory=512m --memory-swap=512m --cpus=1.0 --pids-limit=100 -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 1 2>&1
                   mv results.json ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
             - name: Upload results
               uses: actions/upload-artifact@v4
@@ -474,7 +474,7 @@ jobs:
               run: docker load -i di-benchmark-${{ matrix.container }}.tar
             - name: Run benchmarks
               run: |
-                  docker run --rm -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 5 2>&1
+                  docker run --rm --memory=512m --memory-swap=512m --cpus=1.0 --pids-limit=100 -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 5 2>&1
                   mv results.json ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
             - name: Upload results
               uses: actions/upload-artifact@v4
@@ -519,7 +519,7 @@ jobs:
               run: docker load -i di-benchmark-${{ matrix.container }}.tar
             - name: Run benchmarks
               run: |
-                  docker run --rm -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 1 2>&1
+                  docker run --rm --memory=512m --memory-swap=512m --cpus=1.0 --pids-limit=100 -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 1 2>&1
                   mv results.json ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
             - name: Upload results
               uses: actions/upload-artifact@v4
@@ -567,7 +567,7 @@ jobs:
               run: docker load -i di-benchmark-${{ matrix.container }}.tar
             - name: Run benchmarks
               run: |
-                  docker run --rm -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 1 2>&1
+                  docker run --rm --memory=512m --memory-swap=512m --cpus=1.0 --pids-limit=100 -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 1 2>&1
                   mv results.json ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
             - name: Upload results
               uses: actions/upload-artifact@v4
@@ -612,7 +612,7 @@ jobs:
               run: docker load -i di-benchmark-${{ matrix.container }}.tar
             - name: Run benchmarks
               run: |
-                  docker run --rm -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 1 2>&1
+                  docker run --rm --memory=512m --memory-swap=512m --cpus=1.0 --pids-limit=100 -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 1 2>&1
                   mv results.json ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
             - name: Upload results
               uses: actions/upload-artifact@v4

--- a/proposed-workflow.yml
+++ b/proposed-workflow.yml
@@ -161,7 +161,7 @@ jobs:
               run: docker load -i di-benchmark-${{ matrix.container }}.tar
             - name: Run benchmarks
               run: |
-                  docker run --rm -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 10 2>&1
+                  docker run --rm --memory=512m --memory-swap=512m --cpus=1.0 --pids-limit=100 -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 10 2>&1
                   mv results.json ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
             - name: Upload results
               uses: actions/upload-artifact@v4
@@ -200,7 +200,7 @@ jobs:
               run: docker load -i di-benchmark-${{ matrix.container }}.tar
             - name: Run benchmarks
               run: |
-                  docker run --rm -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 10 2>&1
+                  docker run --rm --memory=512m --memory-swap=512m --cpus=1.0 --pids-limit=100 -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 10 2>&1
                   mv results.json ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
             - name: Upload results
               uses: actions/upload-artifact@v4
@@ -239,7 +239,7 @@ jobs:
               run: docker load -i di-benchmark-${{ matrix.container }}.tar
             - name: Run benchmarks
               run: |
-                  docker run --rm -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 10 2>&1
+                  docker run --rm --memory=512m --memory-swap=512m --cpus=1.0 --pids-limit=100 -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 10 2>&1
                   mv results.json ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
             - name: Upload results
               uses: actions/upload-artifact@v4
@@ -275,7 +275,7 @@ jobs:
               run: docker load -i di-benchmark-${{ matrix.container }}.tar
             - name: Run benchmarks
               run: |
-                  docker run --rm -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 10 2>&1
+                  docker run --rm --memory=512m --memory-swap=512m --cpus=1.0 --pids-limit=100 -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 10 2>&1
                   mv results.json ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
             - name: Upload results
               uses: actions/upload-artifact@v4
@@ -311,7 +311,7 @@ jobs:
               run: docker load -i di-benchmark-${{ matrix.container }}.tar
             - name: Run benchmarks
               run: |
-                  docker run --rm -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 10 2>&1
+                  docker run --rm --memory=512m --memory-swap=512m --cpus=1.0 --pids-limit=100 -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 10 2>&1
                   mv results.json ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
             - name: Upload results
               uses: actions/upload-artifact@v4
@@ -347,7 +347,7 @@ jobs:
               run: docker load -i di-benchmark-${{ matrix.container }}.tar
             - name: Run benchmarks
               run: |
-                  docker run --rm -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 10 2>&1
+                  docker run --rm --memory=512m --memory-swap=512m --cpus=1.0 --pids-limit=100 -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 10 2>&1
                   mv results.json ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
             - name: Upload results
               uses: actions/upload-artifact@v4
@@ -388,7 +388,7 @@ jobs:
               run: docker load -i di-benchmark-${{ matrix.container }}.tar
             - name: Run benchmarks
               run: |
-                  docker run --rm -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 5 2>&1
+                  docker run --rm --memory=512m --memory-swap=512m --cpus=1.0 --pids-limit=100 -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 5 2>&1
                   mv results.json ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
             - name: Upload results
               uses: actions/upload-artifact@v4
@@ -437,7 +437,7 @@ jobs:
               run: docker load -i di-benchmark-${{ matrix.container }}.tar
             - name: Run benchmarks
               run: |
-                  docker run --rm -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 1 2>&1
+                  docker run --rm --memory=512m --memory-swap=512m --cpus=1.0 --pids-limit=100 -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 1 2>&1
                   mv results.json ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
             - name: Upload results
               uses: actions/upload-artifact@v4
@@ -475,7 +475,7 @@ jobs:
               run: docker load -i di-benchmark-${{ matrix.container }}.tar
             - name: Run benchmarks
               run: |
-                  docker run --rm -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 5 2>&1
+                  docker run --rm --memory=512m --memory-swap=512m --cpus=1.0 --pids-limit=100 -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 5 2>&1
                   mv results.json ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
             - name: Upload results
               uses: actions/upload-artifact@v4
@@ -521,7 +521,7 @@ jobs:
               run: docker load -i di-benchmark-${{ matrix.container }}.tar
             - name: Run benchmarks
               run: |
-                  docker run --rm -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 1 2>&1
+                  docker run --rm --memory=512m --memory-swap=512m --cpus=1.0 --pids-limit=100 -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 1 2>&1
                   mv results.json ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
             - name: Upload results
               uses: actions/upload-artifact@v4
@@ -569,7 +569,7 @@ jobs:
               run: docker load -i di-benchmark-${{ matrix.container }}.tar
             - name: Run benchmarks
               run: |
-                  docker run --rm -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 1 2>&1
+                  docker run --rm --memory=512m --memory-swap=512m --cpus=1.0 --pids-limit=100 -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 1 2>&1
                   mv results.json ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
             - name: Upload results
               uses: actions/upload-artifact@v4
@@ -613,7 +613,7 @@ jobs:
               run: docker load -i di-benchmark-${{ matrix.container }}.tar
             - name: Run benchmarks
               run: |
-                  docker run --rm -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 1 2>&1
+                  docker run --rm --memory=512m --memory-swap=512m --cpus=1.0 --pids-limit=100 -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} 1 2>&1
                   mv results.json ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json
             - name: Upload results
               uses: actions/upload-artifact@v4

--- a/tools/update_workflow.php
+++ b/tools/update_workflow.php
@@ -103,7 +103,7 @@ function benchmark_job(string $name, array $needs, array $containers, array $tes
     $yaml .= indent(3) . '  run: docker load -i di-benchmark-${{ matrix.container }}.tar' . "\n";
     $yaml .= indent(3) . "- name: Run benchmarks\n";
     $yaml .= indent(3) . "  run: |\n";
-    $yaml .= indent(4) . '  docker run --rm -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} ' . $iterations . " 2>&1\n";
+    $yaml .= indent(4) . '  docker run --rm --memory=512m --memory-swap=512m --cpus=1.0 --pids-limit=100 -v "$PWD:/out" di-benchmark-${{ matrix.container }} php benchmark.php ${{ matrix.test }} ' . $iterations . " 2>&1\n";
     $yaml .= indent(4) . '  mv results.json ${{ matrix.container }}-${{ matrix.test }}-${{ matrix.run }}.json' . "\n";
     $yaml .= indent(3) . "- name: Upload results\n";
     $yaml .= indent(3) . "  uses: actions/upload-artifact@v4\n";


### PR DESCRIPTION
## Summary
- constrain Docker benchmark runs to 512MB memory, one CPU, and 100 pids
- propagate the new limits through workflow generation

## Testing
- `php -l tools/update_workflow.php`
- `php tools/update_workflow.php`


------
https://chatgpt.com/codex/tasks/task_e_68c1d9c3f298832f8203df015c556522

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Applied resource limits to benchmark containers in the workflow to improve stability and consistency across jobs.

* **Tests**
  * Updated benchmark execution environment with constrained resources; no changes to benchmark commands or logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->