### PR TITLE
docs: add development standards to AGENTS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,3 +29,8 @@ This repository contains PHP benchmark code. These instructions help maintain co
 - `tools/generate_run_summary.php`: builds `run_summary.yaml` and archives it on scheduled runs.
 - `tools/generate_graphs.php`: renders benchmark charts as JPG images.
 - `tools/generate_readme.php`: updates the project README based on the latest results.
+
+## Development Standards
+- Bias Awareness: Special considerations for the "quickly" container (author conflict of interest)
+- Reproducibility: Ensuring consistent environments across different runs
+- Container Isolation: Each container should be completely independent


### PR DESCRIPTION
## Summary
- document development standards including bias awareness for quickly container
- note reproducibility and container isolation requirements

## Testing
- `php -v`


------
https://chatgpt.com/codex/tasks/task_e_68c1e41ae1e8832fae2d3c3a62c7f3c6