### PR TITLE
Add test names to benchmark graph titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,13 +65,13 @@ Some containers perform extra work during the image build; for example, `ray-di.
 | [Zen](https://github.com/woohoolabs/zen) | compiled singleton | Woohoo Labs. Zen DI Container and preload file generator |
 ## Latest Results
 
-Run from 2025-09-10
+Run from 2025-09-11
 
 ### 📊 f06
 
 Small dependency graph including 6 classes total (excluding container startup time)
 
-![📊 f06](images/speed_comparison_without_startup06.jpg)
+![📊 f06](images/speed_comparison_without_startup_f06.jpg)
 
 <details>
 <summary>View results</summary>
@@ -109,7 +109,7 @@ Small dependency graph including 6 classes total (excluding container startup ti
 
 Small dependency graph including 6 classes total (includes container startup time)
 
-![🚀 f06 startup](images/speed_comparison_with_startup06.jpg)
+![🚀 f06 startup](images/speed_comparison_with_startup_f06.jpg)
 
 <details>
 <summary>View results</summary>
@@ -203,7 +203,7 @@ Small interface-based dependency graph including 6 interfaces total (includes co
 
 Medium size dependency graph including 16 classes total. Skipped for the slowest DI-Containers for runtime reasons. (excluding container startup time)
 
-![📊 p16](images/speed_comparison_without_startup16.jpg)
+![📊 p16](images/speed_comparison_without_startup_p16.jpg)
 
 <details>
 <summary>View results</summary>
@@ -234,7 +234,7 @@ Medium size dependency graph including 16 classes total. Skipped for the slowest
 
 Medium size dependency graph including 16 classes total. Skipped for the slowest DI-Containers for runtime reasons. (includes container startup time)
 
-![🚀 p16 startup](images/speed_comparison_with_startup16.jpg)
+![🚀 p16 startup](images/speed_comparison_with_startup_p16.jpg)
 
 <details>
 <summary>View results</summary>
@@ -313,7 +313,7 @@ Medium size interface-based dependency graph including 16 interfaces total. Skip
 
 Large dependency graph including a total of 26 classes. Skipped for all but the fastest DI-Containers for runtime reasons. (excluding container startup time)
 
-![📊 z26](images/speed_comparison_without_startup26.jpg)
+![📊 z26](images/speed_comparison_without_startup_z26.jpg)
 
 <details>
 <summary>View results</summary>
@@ -336,7 +336,7 @@ Large dependency graph including a total of 26 classes. Skipped for all but the 
 
 Large dependency graph including a total of 26 classes. Skipped for all but the fastest DI-Containers for runtime reasons. (includes container startup time)
 
-![🚀 z26 startup](images/speed_comparison_with_startup26.jpg)
+![🚀 z26 startup](images/speed_comparison_with_startup_z26.jpg)
 
 <details>
 <summary>View results</summary>

--- a/tools/generate_graphs.php
+++ b/tools/generate_graphs.php
@@ -192,12 +192,42 @@ if (!is_dir('images')) {
     mkdir('images');
 }
 
-create_bar_chart($withoutStartup06, 'Speed Comparison Without Startup Time (rf06)', 'images/speed_comparison_without_startup06.jpg', $displayNames);
-create_bar_chart($withStartup06, 'Speed Comparison With Startup Time (sf06)', 'images/speed_comparison_with_startup06.jpg', $displayNames);
-create_bar_chart($withoutStartup16, 'Speed Comparison Without Startup Time (rp16)', 'images/speed_comparison_without_startup16.jpg', $displayNames);
-create_bar_chart($withStartup16, 'Speed Comparison With Startup Time (sp16)', 'images/speed_comparison_with_startup16.jpg', $displayNames);
-create_bar_chart($withoutStartup26, 'Speed Comparison Without Startup Time (rz26)', 'images/speed_comparison_without_startup26.jpg', $displayNames);
-create_bar_chart($withStartup26, 'Speed Comparison With Startup Time (sz26)', 'images/speed_comparison_with_startup26.jpg', $displayNames);
+create_bar_chart(
+    $withoutStartup06,
+    'Speed Comparison Without Startup Time (f06)',
+    'images/speed_comparison_without_startup_f06.jpg',
+    $displayNames
+);
+create_bar_chart(
+    $withStartup06,
+    'Speed Comparison With Startup Time (f06_startup)',
+    'images/speed_comparison_with_startup_f06.jpg',
+    $displayNames
+);
+create_bar_chart(
+    $withoutStartup16,
+    'Speed Comparison Without Startup Time (p16)',
+    'images/speed_comparison_without_startup_p16.jpg',
+    $displayNames
+);
+create_bar_chart(
+    $withStartup16,
+    'Speed Comparison With Startup Time (p16_startup)',
+    'images/speed_comparison_with_startup_p16.jpg',
+    $displayNames
+);
+create_bar_chart(
+    $withoutStartup26,
+    'Speed Comparison Without Startup Time (z26)',
+    'images/speed_comparison_without_startup_z26.jpg',
+    $displayNames
+);
+create_bar_chart(
+    $withStartup26,
+    'Speed Comparison With Startup Time (z26_startup)',
+    'images/speed_comparison_with_startup_z26.jpg',
+    $displayNames
+);
 create_bar_chart(
     $withoutStartup06Interfaces,
     'Interface Speed Comparison Without Startup Time',

--- a/tools/generate_graphs.php
+++ b/tools/generate_graphs.php
@@ -192,12 +192,12 @@ if (!is_dir('images')) {
     mkdir('images');
 }
 
-create_bar_chart($withoutStartup06, 'Speed Comparison Without Startup Time', 'images/speed_comparison_without_startup06.jpg', $displayNames);
-create_bar_chart($withStartup06, 'Speed Comparison With Startup Time', 'images/speed_comparison_with_startup06.jpg', $displayNames);
-create_bar_chart($withoutStartup16, 'Speed Comparison Without Startup Time', 'images/speed_comparison_without_startup16.jpg', $displayNames);
-create_bar_chart($withStartup16, 'Speed Comparison With Startup Time', 'images/speed_comparison_with_startup16.jpg', $displayNames);
-create_bar_chart($withoutStartup26, 'Speed Comparison Without Startup Time', 'images/speed_comparison_without_startup26.jpg', $displayNames);
-create_bar_chart($withStartup26, 'Speed Comparison With Startup Time', 'images/speed_comparison_with_startup26.jpg', $displayNames);
+create_bar_chart($withoutStartup06, 'Speed Comparison Without Startup Time (rf06)', 'images/speed_comparison_without_startup06.jpg', $displayNames);
+create_bar_chart($withStartup06, 'Speed Comparison With Startup Time (sf06)', 'images/speed_comparison_with_startup06.jpg', $displayNames);
+create_bar_chart($withoutStartup16, 'Speed Comparison Without Startup Time (rp16)', 'images/speed_comparison_without_startup16.jpg', $displayNames);
+create_bar_chart($withStartup16, 'Speed Comparison With Startup Time (sp16)', 'images/speed_comparison_with_startup16.jpg', $displayNames);
+create_bar_chart($withoutStartup26, 'Speed Comparison Without Startup Time (rz26)', 'images/speed_comparison_without_startup26.jpg', $displayNames);
+create_bar_chart($withStartup26, 'Speed Comparison With Startup Time (sz26)', 'images/speed_comparison_with_startup26.jpg', $displayNames);
 create_bar_chart(
     $withoutStartup06Interfaces,
     'Interface Speed Comparison Without Startup Time',

--- a/tools/generate_readme.php
+++ b/tools/generate_readme.php
@@ -261,12 +261,12 @@ $results = $data['results'] ?? [];
 $tests = [
     'f06' => [
         'title' => '📊 f06',
-        'image' => 'images/speed_comparison_without_startup06.jpg',
+        'image' => 'images/speed_comparison_without_startup_f06.jpg',
         'description' => 'Small dependency graph including 6 classes total (excluding container startup time)'
     ],
     'f06_startup' => [
         'title' => '🚀 f06 startup',
-        'image' => 'images/speed_comparison_with_startup06.jpg',
+        'image' => 'images/speed_comparison_with_startup_f06.jpg',
         'description' => 'Small dependency graph including 6 classes total (includes container startup time)'
     ],
     'fin06' => [
@@ -281,12 +281,12 @@ $tests = [
     ],
     'p16' => [
         'title' => '📊 p16',
-        'image' => 'images/speed_comparison_without_startup16.jpg',
+        'image' => 'images/speed_comparison_without_startup_p16.jpg',
         'description' => 'Medium size dependency graph including 16 classes total. Skipped for the slowest DI-Containers for runtime reasons. (excluding container startup time)'
     ],
     'p16_startup' => [
         'title' => '🚀 p16 startup',
-        'image' => 'images/speed_comparison_with_startup16.jpg',
+        'image' => 'images/speed_comparison_with_startup_p16.jpg',
         'description' => 'Medium size dependency graph including 16 classes total. Skipped for the slowest DI-Containers for runtime reasons. (includes container startup time)'
     ],
     'pin16' => [
@@ -301,12 +301,12 @@ $tests = [
     ],
     'z26' => [
         'title' => '📊 z26',
-        'image' => 'images/speed_comparison_without_startup26.jpg',
+        'image' => 'images/speed_comparison_without_startup_z26.jpg',
         'description' => 'Large dependency graph including a total of 26 classes. Skipped for all but the fastest DI-Containers for runtime reasons. (excluding container startup time)'
     ],
     'z26_startup' => [
         'title' => '🚀 z26 startup',
-        'image' => 'images/speed_comparison_with_startup26.jpg',
+        'image' => 'images/speed_comparison_with_startup_z26.jpg',
         'description' => 'Large dependency graph including a total of 26 classes. Skipped for all but the fastest DI-Containers for runtime reasons. (includes container startup time)'
     ],
     'zin26' => [


### PR DESCRIPTION
## Summary
- Include test identifiers in graph titles to make images easy to correlate with benchmark tests

## Testing
- `php -l tools/generate_graphs.php`


------
https://chatgpt.com/codex/tasks/task_e_68c22ed18130832fb6c6ac978097b1c7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated six speed-comparison chart titles to include run-variant suffixes (e.g., f06 / f06_startup, p16 / p16_startup, z26 / z26_startup) for clearer configuration labeling.
  * Updated corresponding image references in documentation to match the new suffixes.
  * Updated "Latest Results" date in the README.
  * No changes to chart data, labels, or rendering; interface-speed charts unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->