### PR TITLE
Add workflow to deploy static results page

### DIFF
--- a/.github/workflows/deploy-results-page.yml
+++ b/.github/workflows/deploy-results-page.yml
@@ -1,0 +1,50 @@
+---
+name: Deploy results page
+
+'on':
+    workflow_dispatch:
+    push:
+        branches:
+            - the-one
+        paths:
+            - README.md
+            - images/**
+            - .github/workflows/deploy-results-page.yml
+
+permissions:
+    contents: read
+    pages: write
+    id-token: write
+
+concurrency:
+    group: pages
+    cancel-in-progress: true
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v5
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: '20'
+            - name: Build site
+              run: |
+                  mkdir -p public
+                  npx -y marked -o public/index.html README.md
+                  cp run_summary.yaml public/
+                  cp -r images public/
+            - name: Upload artifact
+              uses: actions/upload-pages-artifact@v3
+              with:
+                  path: public
+    deploy:
+        needs: build
+        runs-on: ubuntu-latest
+        environment:
+            name: github-pages
+            url: ${{ steps.deployment.outputs.page_url }}
+        steps:
+            - name: Deploy to GitHub Pages
+              id: deployment
+              uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- add GitHub Pages workflow that builds static results page from README and images

## Testing
- `yamllint .github/workflows/deploy-results-page.yml`


------
https://chatgpt.com/codex/tasks/task_e_68c680f38d24832f8fa7ff4b367b7a11

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a public Results Page hosted on GitHub Pages.
  * Page content is generated from the README and includes images and a run summary for easy viewing.
  * Automatically updates on relevant changes to the “the-one” branch, with an option to trigger updates manually.

* **Chores**
  * Added automated build-and-deploy workflow for the Results Page to ensure consistent, reliable publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->