### PR TITLE
Add CPU and memory badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![PHP Version](https://img.shields.io/badge/PHP-8.4-blue?logo=php) ![Docker Version](https://img.shields.io/badge/Docker-%2A-lightgrey?logo=docker) ![OS](https://img.shields.io/badge/OS-ubuntu%20latest-blue?logo=ubuntu)
 
-> Docker environment runs without network access and with limited CPU and memory resources.
+![Memory](https://img.shields.io/badge/Memory-500MB-blue) ![CPU](https://img.shields.io/badge/CPU-1%20Core-blue)
 
 ![PHP Dependency Injection Benchmark](images/php-dependency-injection-benchmark.jpg)
 
@@ -65,7 +65,7 @@ Some containers perform extra work during the image build; for example, `ray-di.
 | [Zen](https://github.com/woohoolabs/zen) | compiled singleton | Woohoo Labs. Zen DI Container and preload file generator |
 ## Latest Results
 
-Run from 2025-09-11
+Run from 2025-09-14
 
 ### 📊 f06
 

--- a/tools/generate_readme.php
+++ b/tools/generate_readme.php
@@ -81,13 +81,15 @@ $data = parse_simple_yaml('run_summary.yaml');
 $phpBadge = '![PHP Version](https://img.shields.io/badge/PHP-' . rawurlencode($data['php_version']) . '-blue?logo=php)';
 $dockerBadge = '![Docker Version](https://img.shields.io/badge/Docker-' . rawurlencode($data['docker_version'] ?? '*') . '-lightgrey?logo=docker)';
 $osBadge = '![OS](https://img.shields.io/badge/OS-' . rawurlencode($data['os'] ?? 'ubuntu latest') . '-blue?logo=ubuntu)';
+$memoryBadge = '![Memory](https://img.shields.io/badge/Memory-500MB-blue)';
+$cpuBadge = '![CPU](https://img.shields.io/badge/CPU-1%20Core-blue)';
 
 $lines = [];
 $lines[] = '# PHP Dependency Injection Benchmark';
 $lines[] = '';
 $lines[] = $phpBadge . ' ' . $dockerBadge . ' ' . $osBadge;
 $lines[] = '';
-$lines[] = '> Docker environment runs without network access and with limited CPU and memory resources.';
+$lines[] = $memoryBadge . ' ' . $cpuBadge;
 $lines[] = '';
 $lines[] = '![PHP Dependency Injection Benchmark](images/php-dependency-injection-benchmark.jpg)';
 $lines[] = '';


### PR DESCRIPTION
## Summary
- replace environment quote with memory and CPU resource badges
- keep README generator in sync with new badges

## Testing
- `php -l tools/generate_readme.php`
- `php tools/generate_readme.php`


------
https://chatgpt.com/codex/tasks/task_e_68c6a0f1a8d0832f8349137371ba4068

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Replaced the Docker environment note with Memory (500MB) and CPU (1 Core) badges in the README header.
  - Updated the “Latest Results” date to 2025-09-14.
  - Presentation-only changes; no functional impact.

- Chores
  - Updated the README generation to include Memory and CPU badges alongside existing PHP, Docker, and OS badges.
  - No changes to data retrieval or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->