### PR TITLE
Archive all run outputs each day

### DIFF
--- a/tools/generate_run_summary.php
+++ b/tools/generate_run_summary.php
@@ -2,6 +2,34 @@
 
 chdir(__DIR__ . '/..');
 
+function clear_directory(string $directory): void
+{
+    if (!is_dir($directory)) {
+        return;
+    }
+
+    $items = scandir($directory);
+    if ($items === false) {
+        return;
+    }
+
+    foreach ($items as $item) {
+        if ($item === '.' || $item === '..') {
+            continue;
+        }
+
+        $path = $directory . DIRECTORY_SEPARATOR . $item;
+
+        if (is_dir($path)) {
+            clear_directory($path);
+            rmdir($path);
+            continue;
+        }
+
+        unlink($path);
+    }
+}
+
 $files = glob('*.json');
 sort($files);
 $dirs = array_map(fn($f) => pathinfo($f, PATHINFO_FILENAME), $files);
@@ -89,9 +117,21 @@ foreach ($results as $dir => $testsData) {
 }
 file_put_contents('run_summary.yaml', implode("\n", $lines) . "\n");
 
-if (getenv('GITHUB_EVENT_NAME') === 'schedule') {
-    if (!is_dir('archive')) {
-        mkdir('archive', 0777, true);
-    }
-    copy('run_summary.yaml', 'archive/' . $date . '.yaml');
+$archiveBase = 'archive';
+$archiveDir = $archiveBase . '/' . $date;
+
+if (!is_dir($archiveBase)) {
+    mkdir($archiveBase, 0777, true);
+}
+
+if (is_dir($archiveDir)) {
+    clear_directory($archiveDir);
+} else {
+    mkdir($archiveDir, 0777, true);
+}
+
+copy('run_summary.yaml', $archiveDir . '/run_summary.yaml');
+
+foreach ($files as $file) {
+    copy($file, $archiveDir . '/' . basename($file));
 }


### PR DESCRIPTION
## Summary
- always create a dated archive directory for each run
- clear existing daily archives so the latest run replaces earlier ones for the same day
- copy the generated summary and JSON result files into the archive

## Testing
- php -l tools/generate_run_summary.php

------
https://chatgpt.com/codex/tasks/task_e_68cac0d78090832fae23fb9c789c3e4b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Per-date archiving for run summaries, creating date-stamped folders for each run.
  * Archives now include the run summary and related JSON files in a single, organized location.

* **Improvements**
  * Automatic cleanup of existing date archives to prevent stale files.
  * Ensures archive directories are created when missing for smoother archiving.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->