### PR TITLE
Add composer install optimization flags

### DIFF
--- a/containers/aura-di.configured.transient/Dockerfile
+++ b/containers/aura-di.configured.transient/Dockerfile
@@ -7,6 +7,6 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends git unzip \
     && rm -rf /var/lib/apt/lists/* \
     && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
-    && composer install --no-interaction --no-progress
+    && composer install --no-interaction --no-progress --no-dev --prefer-dist --classmap-authoritative
 COPY src/*.php ./
 CMD ["php", "benchmark.php"]

--- a/containers/auryn.reflection.transient/Dockerfile
+++ b/containers/auryn.reflection.transient/Dockerfile
@@ -7,6 +7,6 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends git unzip \
     && rm -rf /var/lib/apt/lists/* \
     && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
-    && composer install --no-interaction --no-progress
+    && composer install --no-interaction --no-progress --no-dev --prefer-dist --classmap-authoritative
 COPY src/*.php ./
 CMD ["php", "benchmark.php"]

--- a/containers/dice.configured.singleton/Dockerfile
+++ b/containers/dice.configured.singleton/Dockerfile
@@ -7,6 +7,6 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends git unzip \
     && rm -rf /var/lib/apt/lists/* \
     && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
-    && composer install --no-interaction --no-progress
+    && composer install --no-interaction --no-progress --no-dev --prefer-dist --classmap-authoritative
 COPY src/*.php ./
 CMD ["php", "benchmark.php"]

--- a/containers/dice.reflection.transient/Dockerfile
+++ b/containers/dice.reflection.transient/Dockerfile
@@ -7,6 +7,6 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends git unzip \
     && rm -rf /var/lib/apt/lists/* \
     && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
-    && composer install --no-interaction --no-progress
+    && composer install --no-interaction --no-progress --no-dev --prefer-dist --classmap-authoritative
 COPY src/*.php ./
 CMD ["php", "benchmark.php"]

--- a/containers/laminas-servicemanager.reflection.singleton/Dockerfile
+++ b/containers/laminas-servicemanager.reflection.singleton/Dockerfile
@@ -7,6 +7,6 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends git unzip \
     && rm -rf /var/lib/apt/lists/* \
     && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
-    && composer install --no-interaction --no-progress
+    && composer install --no-interaction --no-progress --no-dev --prefer-dist --classmap-authoritative
 COPY src/*.php ./
 CMD ["php", "benchmark.php"]

--- a/containers/laravel.configured.transient/Dockerfile
+++ b/containers/laravel.configured.transient/Dockerfile
@@ -7,6 +7,6 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends git unzip \
     && rm -rf /var/lib/apt/lists/* \
     && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
-    && composer install --no-interaction --no-progress
+    && composer install --no-interaction --no-progress --no-dev --prefer-dist --classmap-authoritative
 COPY src/*.php ./
 CMD ["php", "benchmark.php"]

--- a/containers/laravel.reflection.singleton/Dockerfile
+++ b/containers/laravel.reflection.singleton/Dockerfile
@@ -7,6 +7,6 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends git unzip \
     && rm -rf /var/lib/apt/lists/* \
     && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
-    && composer install --no-interaction --no-progress
+    && composer install --no-interaction --no-progress --no-dev --prefer-dist --classmap-authoritative
 COPY src/*.php ./
 CMD ["php", "benchmark.php"]

--- a/containers/laravel.reflection.transient/Dockerfile
+++ b/containers/laravel.reflection.transient/Dockerfile
@@ -7,6 +7,6 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends git unzip \
     && rm -rf /var/lib/apt/lists/* \
     && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
-    && composer install --no-interaction --no-progress
+    && composer install --no-interaction --no-progress --no-dev --prefer-dist --classmap-authoritative
 COPY src/*.php ./
 CMD ["php", "benchmark.php"]

--- a/containers/league.configured.transient/Dockerfile
+++ b/containers/league.configured.transient/Dockerfile
@@ -7,6 +7,6 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends git unzip \
     && rm -rf /var/lib/apt/lists/* \
     && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
-    && composer install --no-interaction --no-progress
+    && composer install --no-interaction --no-progress --no-dev --prefer-dist --classmap-authoritative
 COPY src/*.php ./
 CMD ["php", "benchmark.php"]

--- a/containers/league.reflection.transient/Dockerfile
+++ b/containers/league.reflection.transient/Dockerfile
@@ -7,6 +7,6 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends git unzip \
     && rm -rf /var/lib/apt/lists/* \
     && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
-    && composer install --no-interaction --no-progress
+    && composer install --no-interaction --no-progress --no-dev --prefer-dist --classmap-authoritative
 COPY src/*.php ./
 CMD ["php", "benchmark.php"]

--- a/containers/nette-di.compiled.singleton/Dockerfile
+++ b/containers/nette-di.compiled.singleton/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends git unzip \
     && rm -rf /var/lib/apt/lists/* \
     && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
-    && composer install --no-interaction --no-progress
+    && composer install --no-interaction --no-progress --no-dev --prefer-dist --classmap-authoritative
 COPY src/*.php ./
 RUN php compile.php
 CMD ["php", "benchmark.php"]

--- a/containers/phalcon.configured.singleton/Dockerfile
+++ b/containers/phalcon.configured.singleton/Dockerfile
@@ -13,6 +13,6 @@ RUN chmod +x /usr/local/bin/install-php-extensions \
     && docker-php-ext-enable psr \
     && docker-php-ext-enable phalcon \
     && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
-    && composer install --no-interaction --no-progress
+    && composer install --no-interaction --no-progress --no-dev --prefer-dist --classmap-authoritative
 COPY src/*.php ./
 CMD ["php", "benchmark.php"]

--- a/containers/phalcon.configured.transient/Dockerfile
+++ b/containers/phalcon.configured.transient/Dockerfile
@@ -13,6 +13,6 @@ RUN chmod +x /usr/local/bin/install-php-extensions \
     && docker-php-ext-enable psr \
     && docker-php-ext-enable phalcon \
     && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
-    && composer install --no-interaction --no-progress
+    && composer install --no-interaction --no-progress --no-dev --prefer-dist --classmap-authoritative
 COPY src/*.php ./
 CMD ["php", "benchmark.php"]

--- a/containers/php-baseline/Dockerfile
+++ b/containers/php-baseline/Dockerfile
@@ -7,6 +7,6 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends git unzip \
     && rm -rf /var/lib/apt/lists/* \
     && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
-    && composer install --no-interaction --no-progress
+    && composer install --no-interaction --no-progress --no-dev --prefer-dist --classmap-authoritative
 COPY src/*.php ./
 CMD ["php", "benchmark.php"]

--- a/containers/php-di.reflection.singleton/Dockerfile
+++ b/containers/php-di.reflection.singleton/Dockerfile
@@ -7,6 +7,6 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends git unzip \
     && rm -rf /var/lib/apt/lists/* \
     && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
-    && composer install --no-interaction --no-progress
+    && composer install --no-interaction --no-progress --no-dev --prefer-dist --classmap-authoritative
 COPY src/*.php ./
 CMD ["php", "benchmark.php"]

--- a/containers/pimple.configured.singleton/Dockerfile
+++ b/containers/pimple.configured.singleton/Dockerfile
@@ -7,6 +7,6 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends git unzip \
     && rm -rf /var/lib/apt/lists/* \
     && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
-    && composer install --no-interaction --no-progress
+    && composer install --no-interaction --no-progress --no-dev --prefer-dist --classmap-authoritative
 COPY src/*.php ./
 CMD ["php", "benchmark.php"]

--- a/containers/pimple.configured.transient/Dockerfile
+++ b/containers/pimple.configured.transient/Dockerfile
@@ -7,6 +7,6 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends git unzip \
     && rm -rf /var/lib/apt/lists/* \
     && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
-    && composer install --no-interaction --no-progress
+    && composer install --no-interaction --no-progress --no-dev --prefer-dist --classmap-authoritative
 COPY src/*.php ./
 CMD ["php", "benchmark.php"]

--- a/containers/quickly.compiled.singleton/Dockerfile
+++ b/containers/quickly.compiled.singleton/Dockerfile
@@ -10,6 +10,6 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends git unzip \
     && rm -rf /var/lib/apt/lists/* \
     && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
-    && composer install --no-interaction --no-dev --no-progress
+    && composer install --no-interaction --no-dev --no-progress --prefer-dist --classmap-authoritative
 RUN vendor/bin/quickly build
 CMD ["php", "benchmark.php"]

--- a/containers/quickly.configured.singleton/Dockerfile
+++ b/containers/quickly.configured.singleton/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends git unzip \
     && rm -rf /var/lib/apt/lists/* \
     && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
-    && composer install --no-interaction --no-progress
+    && composer install --no-interaction --no-progress --no-dev --prefer-dist --classmap-authoritative
 RUN vendor/bin/quickly build
 CMD ["php", "benchmark.php"]
 

--- a/containers/quickly.reflection.singleton/Dockerfile
+++ b/containers/quickly.reflection.singleton/Dockerfile
@@ -7,6 +7,6 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends git unzip \
     && rm -rf /var/lib/apt/lists/* \
     && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
-    && composer install --no-interaction --no-progress
+    && composer install --no-interaction --no-progress --no-dev --prefer-dist --classmap-authoritative
 COPY src/*.php ./
 CMD ["php", "benchmark.php"]

--- a/containers/ray-di.compiled.transient/Dockerfile
+++ b/containers/ray-di.compiled.transient/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends git unzip \
     && rm -rf /var/lib/apt/lists/* \
     && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
-    && composer install --no-interaction --no-progress
+    && composer install --no-interaction --no-progress --no-dev --prefer-dist --classmap-authoritative
 COPY src/*.php ./
 RUN php build.php
 CMD ["php", "benchmark.php"]

--- a/containers/ray-di.reflection.transient/Dockerfile
+++ b/containers/ray-di.reflection.transient/Dockerfile
@@ -7,6 +7,6 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends git unzip \
     && rm -rf /var/lib/apt/lists/* \
     && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
-    && composer install --no-interaction --no-progress
+    && composer install --no-interaction --no-progress --no-dev --prefer-dist --classmap-authoritative
 COPY src/*.php ./
 CMD ["php", "benchmark.php"]

--- a/containers/symfony.compiled.singleton/Dockerfile
+++ b/containers/symfony.compiled.singleton/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends git unzip \
     && rm -rf /var/lib/apt/lists/* \
     && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
-    && composer install --no-interaction --no-progress
+    && composer install --no-interaction --no-progress --no-dev --prefer-dist --classmap-authoritative
 COPY src/*.php ./
 RUN php build.php
 CMD ["php", "benchmark.php"]

--- a/containers/zen.compiled.singleton/Dockerfile
+++ b/containers/zen.compiled.singleton/Dockerfile
@@ -7,6 +7,6 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends git unzip \
     && rm -rf /var/lib/apt/lists/* \
     && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
-    && composer install --no-interaction --no-progress
+    && composer install --no-interaction --no-progress --no-dev --prefer-dist --classmap-authoritative
 COPY src/*.php ./
 CMD ["php", "benchmark.php"]


### PR DESCRIPTION
## Summary
- add the --no-dev, --prefer-dist, and --classmap-authoritative options to every composer install command in container Dockerfiles to optimize dependency installation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd0c05833c832f935e173b6584d6f7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Standardized Composer installation across container images to install production dependencies only, prefer distribution packages, and use authoritative classmaps.
  - Results in smaller images and faster dependency installation during builds.
  - Improves autoloading performance, potentially reducing startup time.
  - No changes to application behavior or commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->