### PR TITLE
Enable strict typing across PHP sources

### DIFF
--- a/containers/aura-di.configured.transient/AdapterImplementation.php
+++ b/containers/aura-di.configured.transient/AdapterImplementation.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Aura\Di\ContainerBuilder;
 
 class AdapterImplementation

--- a/containers/auryn.reflection.transient/AdapterImplementation.php
+++ b/containers/auryn.reflection.transient/AdapterImplementation.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Auryn\Injector;
 
 class AdapterImplementation

--- a/containers/dice.configured.singleton/AdapterImplementation.php
+++ b/containers/dice.configured.singleton/AdapterImplementation.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Dice\Dice;
 
 class AdapterImplementation

--- a/containers/dice.reflection.transient/AdapterImplementation.php
+++ b/containers/dice.reflection.transient/AdapterImplementation.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Dice\Dice;
 
 class AdapterImplementation

--- a/containers/laminas-servicemanager.reflection.singleton/AdapterImplementation.php
+++ b/containers/laminas-servicemanager.reflection.singleton/AdapterImplementation.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Laminas\ServiceManager\ServiceManager;
 use Laminas\ServiceManager\AbstractFactory\ReflectionBasedAbstractFactory;
 

--- a/containers/laravel.configured.transient/AdapterImplementation.php
+++ b/containers/laravel.configured.transient/AdapterImplementation.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Illuminate\Container\Container;
 
 class AdapterImplementation

--- a/containers/laravel.reflection.singleton/AdapterImplementation.php
+++ b/containers/laravel.reflection.singleton/AdapterImplementation.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Illuminate\Container\Container;
 
 class AdapterImplementation

--- a/containers/laravel.reflection.transient/AdapterImplementation.php
+++ b/containers/laravel.reflection.transient/AdapterImplementation.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Illuminate\Container\Container;
 
 class AdapterImplementation

--- a/containers/league.configured.transient/AdapterImplementation.php
+++ b/containers/league.configured.transient/AdapterImplementation.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use League\Container\Container;
 
 class AdapterImplementation

--- a/containers/league.reflection.transient/AdapterImplementation.php
+++ b/containers/league.reflection.transient/AdapterImplementation.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use League\Container\Container;
 use League\Container\ReflectionContainer;
 

--- a/containers/nette-di.compiled.singleton/AdapterImplementation.php
+++ b/containers/nette-di.compiled.singleton/AdapterImplementation.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 require_once __DIR__ . '/CompiledContainer.php';
 
 class AdapterImplementation

--- a/containers/nette-di.compiled.singleton/compile.php
+++ b/containers/nette-di.compiled.singleton/compile.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 require __DIR__ . '/vendor/autoload.php';
 require __DIR__ . '/classes-06.php';
 require __DIR__ . '/classes-16.php';

--- a/containers/phalcon.configured.singleton/AdapterImplementation.php
+++ b/containers/phalcon.configured.singleton/AdapterImplementation.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Phalcon\Di\Di;
 
 class AdapterImplementation

--- a/containers/phalcon.configured.transient/AdapterImplementation.php
+++ b/containers/phalcon.configured.transient/AdapterImplementation.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Phalcon\Di\Di;
 
 class AdapterImplementation

--- a/containers/php-baseline/AdapterImplementation.php
+++ b/containers/php-baseline/AdapterImplementation.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class AdapterImplementation
 {
     private array $cache = [];

--- a/containers/php-di.reflection.singleton/AdapterImplementation.php
+++ b/containers/php-di.reflection.singleton/AdapterImplementation.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use DI\ContainerBuilder;
 
 use function DI\create;

--- a/containers/pimple.configured.singleton/AdapterImplementation.php
+++ b/containers/pimple.configured.singleton/AdapterImplementation.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Pimple\Container;
 
 class AdapterImplementation

--- a/containers/pimple.configured.transient/AdapterImplementation.php
+++ b/containers/pimple.configured.transient/AdapterImplementation.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Pimple\Container;
 
 class AdapterImplementation

--- a/containers/quickly.compiled.singleton/.quickly/entrypoints.php
+++ b/containers/quickly.compiled.singleton/.quickly/entrypoints.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 return [
     F06::class,
     FIn06::class,

--- a/containers/quickly.compiled.singleton/AdapterImplementation.php
+++ b/containers/quickly.compiled.singleton/AdapterImplementation.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Idrinth\Quickly\Built\DependendyInjection\Container as QuicklyContainer;
 use Psr\Container\ContainerInterface;
 

--- a/containers/quickly.configured.singleton/.quickly/entrypoints.php
+++ b/containers/quickly.configured.singleton/.quickly/entrypoints.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 return [
     F06::class,
     FIn06::class,

--- a/containers/quickly.configured.singleton/AdapterImplementation.php
+++ b/containers/quickly.configured.singleton/AdapterImplementation.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Idrinth\Quickly\DependencyInjection\Container as QuicklyContainer;
 use Psr\Container\ContainerInterface;
 

--- a/containers/quickly.reflection.singleton/AdapterImplementation.php
+++ b/containers/quickly.reflection.singleton/AdapterImplementation.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Idrinth\Quickly\DependencyInjection\Container as QuicklyContainer;
 use Psr\Container\ContainerInterface;
 

--- a/containers/ray-di.compiled.transient/AdapterImplementation.php
+++ b/containers/ray-di.compiled.transient/AdapterImplementation.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Ray\Compiler\CompiledInjector;
 
 class AdapterImplementation

--- a/containers/ray-di.compiled.transient/build.php
+++ b/containers/ray-di.compiled.transient/build.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Ray\Compiler\Compiler;
 use Ray\Di\AbstractModule;
 

--- a/containers/ray-di.reflection.transient/AdapterImplementation.php
+++ b/containers/ray-di.reflection.transient/AdapterImplementation.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Ray\Di\AbstractModule;
 use Ray\Di\Injector;
 

--- a/containers/symfony.compiled.singleton/AdapterImplementation.php
+++ b/containers/symfony.compiled.singleton/AdapterImplementation.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 require __DIR__ . '/CompiledContainer.php';
 
 class AdapterImplementation

--- a/containers/symfony.compiled.singleton/build.php
+++ b/containers/symfony.compiled.singleton/build.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Dumper\PhpDumper;
 

--- a/containers/zen.compiled.singleton/AdapterImplementation.php
+++ b/containers/zen.compiled.singleton/AdapterImplementation.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use WoohooLabs\Zen\RuntimeContainer;
 use WoohooLabs\Zen\Config\AbstractCompilerConfig;
 use WoohooLabs\Zen\Config\AbstractContainerConfig;

--- a/src/benchmark.php
+++ b/src/benchmark.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 require_once __DIR__ . '/vendor/autoload.php';
 require_once __DIR__ . '/AdapterImplementation.php';
 require_once __DIR__ . '/classes-06.php';

--- a/src/classes-06.php
+++ b/src/classes-06.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class A06
 {
 }

--- a/src/classes-16.php
+++ b/src/classes-16.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class A16
 {
 }

--- a/src/classes-26.php
+++ b/src/classes-26.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class A26
 {
 }

--- a/src/interfaces-06.php
+++ b/src/interfaces-06.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 interface AIn06
 {
 }

--- a/src/interfaces-16.php
+++ b/src/interfaces-16.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 interface AIn16
 {
 }

--- a/src/interfaces-26.php
+++ b/src/interfaces-26.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 interface AIn26
 {
 }

--- a/tools/generate_graphs.php
+++ b/tools/generate_graphs.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 chdir(__DIR__ . '/..');
 
 function format_name(string $name): string

--- a/tools/generate_readme.php
+++ b/tools/generate_readme.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 chdir(__DIR__ . '/..');
 
 function parse_simple_yaml(string $filename): array

--- a/tools/generate_run_summary.php
+++ b/tools/generate_run_summary.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 chdir(__DIR__ . '/..');
 
 $files = glob('*.json');

--- a/tools/merge_json.php
+++ b/tools/merge_json.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 chdir(__DIR__ . '/..');
 
 function merge_json_files(array $files): array

--- a/tools/update_workflow.php
+++ b/tools/update_workflow.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 chdir(__DIR__ . '/..');
 
 function parse_run_summary(string $filename): array


### PR DESCRIPTION
## Summary
- add strict typing declarations to every PHP file missing them across src, containers, and tools

## Testing
- php -l (for each modified file)


------
https://chatgpt.com/codex/tasks/task_e_68cd0c28beec832f95007218c338ea88

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added four new entrypoints to the Quickly (compiled singleton) container, broadening supported scenarios.
- Refactor
  - Enabled strict typing across containers, benchmarks, and tooling for more predictable type behavior without changing public APIs.
- Chores
  - Applied consistent strict type declarations throughout build and utility scripts to enhance robustness and error detection.
- Tests
  - No user-facing test changes.
- Documentation
  - No documentation updates in this release.
- Bug Fixes
  - No bug fixes included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->