### PR TITLE
Fix quoted string parsing for README generator

### DIFF
--- a/tools/generate_readme.php
+++ b/tools/generate_readme.php
@@ -20,6 +20,14 @@ function parse_simple_yaml(string $filename): array
         $indent = strlen($matches[1]);
         $key = rtrim($matches[2]);
         $valuePart = isset($matches[3]) ? trim($matches[3]) : '';
+        $isQuoted = false;
+        if ($valuePart !== '') {
+            $firstChar = $valuePart[0];
+            $lastChar = $valuePart[strlen($valuePart) - 1];
+            if (($firstChar === "'" && $lastChar === "'") || ($firstChar === '"' && $lastChar === '"')) {
+                $isQuoted = true;
+            }
+        }
         while ($indent < end($indentStack)) {
             array_pop($indentStack);
             array_pop($refStack);
@@ -30,7 +38,7 @@ function parse_simple_yaml(string $filename): array
             $indentStack[] = $indent + 2;
         } else {
             $value = trim($valuePart, "'\"");
-            if (is_numeric($value)) {
+            if (!$isQuoted && is_numeric($value)) {
                 $value = str_contains($value, '.') ? (float)$value : (int)$value;
             }
             $refStack[count($refStack) - 1][$key] = $value;


### PR DESCRIPTION
## Summary
- detect when scalar values in the simple YAML parser are quoted
- retain quoted values as strings instead of casting them to numbers
- prevent type errors in README badge generation for version strings

## Testing
- php -l tools/generate_readme.php

------
https://chatgpt.com/codex/tasks/task_e_68cd6f5a1348832fbdd030d09b22d945

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * YAML-like parsing now respects quotes: values enclosed in single or double quotes are preserved as strings.
  * Prevents unintended numeric conversion for quoted numbers (e.g., "0012", "3.14" remain strings).
  * Unquoted numeric values continue to be cast to integers/floats as before.
  * Existing handling for empty values and arrays remains unchanged.
  * No changes to public interfaces; behavior improvements are internal but user-visible in parsed output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->